### PR TITLE
Pyo3 update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,11 @@ pub fn start_server() {
 }
 
 #[pymodule]
-pub fn robyn(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+pub fn robyn(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // the pymodule class to make the rustPyFunctions available
     // in python
     m.add_wrapped(wrap_pyfunction!(start_server))?;
     m.add_class::<Server>()?;
-    pyo3_asyncio::try_init(py)?;
     pyo3::prepare_freethreaded_python();
     Ok(())
 }

--- a/test.py
+++ b/test.py
@@ -54,4 +54,4 @@ def blocker():
 
 if __name__ == "__main__":
     app.add_header("server", "robyn")
-    app.start(port=5001)
+    app.start(port=5000)


### PR DESCRIPTION
Hey, the fix was a bit more complicated than I anticipated. Essentially, since you're using `run_forever`, there was no way of getting the event loop reference via `get_running_loop` as opposed to `get_event_loop` (which will fetch the global event loop). I went ahead and scoped the event loop for your `index` handler so that it has access to the event loop via task-local data.

I've been improving the docs on 0.14, but this problem probably isn't explicitly addressed. The "Event Loop References and Thread-Awareness" section in the docs may provide some intuition for why 0.14 acts this way.