### PR TITLE
Make the request object accessible in every route

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -75,7 +75,7 @@ impl Server {
                             app = app.service(
                                 Files::new(&directory.route, &directory.directory_path)
                                     .index_file(index_file)
-                                    .redirect_to_slash_directory(), // .show_files_listing(), // .index_file(index_file),
+                                    .redirect_to_slash_directory(),
                             );
                         } else if directory.show_files_listing {
                             app = app.service(

--- a/test.py
+++ b/test.py
@@ -7,7 +7,8 @@ callCount = 0
 
 
 @app.get("/")
-async def h():
+async def h(request):
+    print(request)
     global callCount
     callCount += 1
     message = "Called " + str(callCount) + " times"


### PR DESCRIPTION
Partial fix to https://github.com/sansyrox/robyn/issues/72

Make the request object accessible in every route