### PR TITLE
URL queries

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 flake8==4.0.1
 black==21.12b0
+websockets==10.1

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,6 +102,17 @@ async def json(request):
     return jsonify({"hello": "world"})
 ```
 
+### Getting URL form data
+You can access URL form data with the request object similar to how you access params.
+
+```python3
+@app.get("/get")
+async def query(request):
+    form_data = request.get("queries", {})
+    print(form_data)
+    return jsonify({"queries": form_data})
+```
+
 ### Returning a JSON Response
 You can also serve JSON responses when serving HTTP request using the following way.
 

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -51,6 +51,11 @@ async def test(request):
 async def json_get():
     return jsonify({"hello": "world"})
 
+@app.get("/query")
+async def query_get(request):
+    query_data = request["queries"]
+    return jsonify(query_data)
+
 
 @app.post("/jsonify/:id")
 async def json(request):

--- a/integration_tests/test_get_requests.py
+++ b/integration_tests/test_get_requests.py
@@ -15,3 +15,9 @@ def test_html(session):
     r = requests.get(f"{BASE_URL}/test/123")
     assert "Hello world. How are you?" in r.text
 
+def test_queries(session):
+    r = requests.get(f"{BASE_URL}/query?hello=robyn")
+    assert r.json()=={"hello":"robyn"}
+
+    r = requests.get(f"{BASE_URL}/query")
+    assert r.json()=={}

--- a/src/server.rs
+++ b/src/server.rs
@@ -235,11 +235,14 @@ async fn index(
     mut payload: web::Payload,
     req: HttpRequest,
 ) -> impl Responder {
-    let split = req.query_string().split("&");
     let mut queries = HashMap::new();
-    for s in split {
-        let params = s.split_once("=").unwrap_or(("", ""));
-        queries.insert(params.0, params.1);
+    
+    if req.query_string().len() > 0 {
+        let split = req.query_string().split("&");
+        for s in split {
+            let params = s.split_once("=").unwrap_or((s, ""));
+            queries.insert(params.0, params.1);
+        }
     }
 
     match router.get_route(req.method().clone(), req.uri().path()) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 use std::sync::{Arc, RwLock};
 use std::thread;
+use std::collections::HashMap;
 
 use actix_files::Files;
 use actix_http::KeepAlive;
@@ -234,6 +235,13 @@ async fn index(
     mut payload: web::Payload,
     req: HttpRequest,
 ) -> impl Responder {
+    let split = req.query_string().split("&");
+    let mut queries = HashMap::new();
+    for s in split {
+        let params = s.split_once("=").unwrap_or(("", ""));
+        queries.insert(params.0, params.1);
+    }
+
     match router.get_route(req.method().clone(), req.uri().path()) {
         Some(((handler_function, number_of_params), route_params)) => {
             handle_request(
@@ -243,6 +251,7 @@ async fn index(
                 &mut payload,
                 &req,
                 route_params,
+                queries,
             )
             .await
         }


### PR DESCRIPTION
**Description**

This PR adds support for URL form queries, which do not match REST-like patterns such as `/path/<id>`. The Rust side already has access to query strings for requests to paths such as `/path?foo=bar`. This data is made available on the Python side as a dict object similar to headers under the key name `queries`.

Docs and tests have been updated to reflect changes.

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->