### PR TITLE
Use print instead of input after starting server

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -88,7 +88,7 @@ class Robyn:
                 )
                 p.start()
 
-            input("Press Cntrl + C to stop \n")
+            print("Press Ctrl + C to stop \n")
         else:
             event_handler = EventHandler(self.file_path)
             event_handler.start_server_first_time()


### PR DESCRIPTION
**Description**

This super short PR fixes the usage of `input` after starting the server and replaces it with `print`.

The main problem solved is the necessity of having a TTY attached in case we use `input` - for example, with the previous `input`, Docker was failing if running without interactive mode. 

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->