### PR TITLE
fix typo :pencil2: in api docs.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -283,7 +283,7 @@ def hello_after_request(request):
     print(request)
 ```
 
-## MutliCore Scaling
+## MultiCore Scaling
 
 To run Robyn across multiple cores, you can use the following command:
 


### PR DESCRIPTION
**Description**

This PR just fixs a typo in api docs.