### PR TITLE
Adds pre-commit hooks for black, flake8, isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+default_stages: [push]
 repos:
 -   repo: https://github.com/psf/black
     rev: 21.12b0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: 21.12b0
     hooks:
     - id: black
+      args: [--line-length=160]
 -   repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+    - id: black
+-   repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+    - id: flake8
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+    - id: isort

--- a/README.md
+++ b/README.md
@@ -66,11 +66,15 @@ If you're feeling curious. You can take a look at a more detailed architecture [
 
 ## ⚙️ To Develop Locally
 
+1. Install the development dependencies: `pip install -r dev-requirements.txt`
+
+1. Install the pre-commit git hooks: `pre-commit install`
+
 1. Add more routes in the `integration_tests/base_routes.py` file(if you like).
 
-2. Run `maturin develop` or `maturin develop --cargo-extra-args="--features=io-uring"` (if you want to run the experimental version).
+1. Run `maturin develop` or `maturin develop --cargo-extra-args="--features=io-uring"` (if you want to run the experimental version).
 
-3. Run `python3 integration_tests/base_routes.py`
+1. Run `python3 integration_tests/base_routes.py`
 
 ## 🏃 To Run
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ black==21.12b0
 websockets==10.1
 maturin==0.12.11
 isort==5.10.1
+pre-commit==2.19.0


### PR DESCRIPTION
**Description**

This PR fixes #194

Ran into this issue with new install of [black](https://github.com/psf/black/issues/2964), but the pre-commit hook should be correct.

Questions for reviewer:
- Is there somewhere I should add documentation on installing and running pre-commit hooks (e.g., README.md or CONTRIBUTING.md)?
- Do you use the default line length with black? Any other settings that should be specified for other hooks?

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->