### PR TITLE
Add Rust CI

### DIFF
--- a/.github/workflows/rust-CI.yml
+++ b/.github/workflows/rust-CI.yml
@@ -1,0 +1,64 @@
+on: [push, pull_request]
+
+name: Rust Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -129,7 +129,7 @@ pub async fn execute_function(
     number_of_params: u8,
     is_async: bool,
 ) -> Result<HashMap<String, String>> {
-    let mut request: HashMap<String, String> = HashMap::new();
+    let request: HashMap<String, String> = HashMap::new();
 
     if is_async {
         let output = Python::with_gil(|py| {

--- a/src/request_handler/mod.rs
+++ b/src/request_handler/mod.rs
@@ -72,7 +72,7 @@ pub async fn handle_http_request(
     debug!("These are the headers from serde {:?}", headers);
 
     let mut response = HttpResponse::build(status_code);
-    apply_headers(&mut response, headers.clone());
+    apply_headers(&mut response, headers);
     let final_response = if !body.is_empty() {
         response.body(body)
     } else {

--- a/src/routers/const_router.rs
+++ b/src/routers/const_router.rs
@@ -1,7 +1,7 @@
+use std::sync::Arc;
 use std::sync::RwLock;
-use std::{collections::HashMap, sync::Arc};
 // pyo3 modules
-use crate::{executors::execute_function, types::PyFunction};
+use crate::executors::execute_function;
 use log::debug;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
@@ -115,8 +115,9 @@ impl ConstRouter {
     ) -> Option<String> {
         // need to split this function in multiple smaller functions
         let table = self.get_relevant_map(route_method)?;
+        let route_map = table.read().ok()?;
 
-        match table.clone().read().unwrap().at(route) {
+        match route_map.at(route) {
             Ok(res) => Some(res.value.clone()),
             Err(_) => None,
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -253,6 +253,7 @@ impl Server {
 
     /// Add a new route to the routing tables
     /// can be called after the server has been started
+    #[allow(clippy::too_many_arguments)]
     pub fn add_route(
         &self,
         py: Python,
@@ -425,7 +426,7 @@ async fn index(
         }
     };
 
-    let _ = match middleware_router.get_route("AFTER_REQUEST", req.uri().path()) {
+    match middleware_router.get_route("AFTER_REQUEST", req.uri().path()) {
         Some(((handler_function, number_of_params), route_params)) => {
             let x = handle_http_middleware_request(
                 handler_function,


### PR DESCRIPTION
**Description**
- Fix Rust clippy warnings
- Add a CI for the Rust part of the project, running cargo check, cargo test, cargo fmt, and cargo clippy

**Notes**
- I added more than just clippy, let me know if you want to remove some stuff
- There are two different CI systems in the project : Github Actions and Circle CI. I added the Rust CI to the Github Actions CI because that's what I am the most familiar with. Is there a reason why Circle CI is used for testing the Python part of Robyn? If you prefer having the Rust CI on Circle CI I think I can figure it out and move it there :)

This PR fixes #236

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->