### PR TITLE
fix: enable hot reload on windows

### DIFF
--- a/robyn/dev_event_handler.py
+++ b/robyn/dev_event_handler.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from watchdog.events import FileSystemEventHandler
 
@@ -7,11 +8,14 @@ class EventHandler(FileSystemEventHandler):
     def __init__(self, file_name) -> None:
         self.file_name = file_name
         self.processes = []
+        self.python_alias = "python3" if not sys.platform.startswith("win32") else "python"
+        self.shell = True if sys.platform.startswith("win32") else False
+        
 
     def start_server_first_time(self) -> None:
         if self.processes:
             raise Exception("Something wrong with the server")
-        self.processes.append(subprocess.Popen(["python3", self.file_name], start_new_session=False))
+        self.processes.append(subprocess.Popen([self.python_alias, self.file_name], shell = self.shell, start_new_session=False))
 
     def on_any_event(self, event) -> None:
         """
@@ -22,5 +26,5 @@ class EventHandler(FileSystemEventHandler):
 
         if len(self.processes) > 0:
             for process in self.processes:
-                process.terminate()
-        self.processes.append(subprocess.Popen(["python3", self.file_name], start_new_session=False))
+                process.terminate()         
+        self.processes.append(subprocess.Popen([self.python_alias, self.file_name], shell = self.shell, start_new_session=False))


### PR DESCRIPTION
**Description**

Concerned with issue/bug #283

### Changes
* fix(dev_event_handler.py): use platform specific python3 alias to spawn processes 

### Documentation
No documentation update is required

### How I've tested my work 
* **26/26** tests passed (Debian 10)
* **25/26** tests passed (Windows 10) (`global_index_request()` failed) 

### Remarks
* Although this minute code change gets the `dev_index_request()` test passed on windows, for some reason hot reload fails to work on my system. 

     * **Windows:** Inside `dev_event_handler.py`, function `on_any_event()` gets called every time I make a change in the `base_routes.py` file but I cannot see changes being reflected on the browser. 
     * **Debian:**  Inside `dev_event_handler.py`, function `on_any_event()` does not get called when I make a change in the `base_routes.py` file and thus I cannot see changes being reflected on the browser. 
     * I just want to make sure if this is a problem that everyone else is experiencing or is it only me?

* Failure of `global_index_request()` test persists
