### PR TITLE
 Hotfix detecting robyn.env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "robyn"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "actix",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robyn"
-version = "0.17.5"
+version = "0.18.0"
 authors = ["Sanskar Jethi <sansyrox@gmail.com>"]
 edition = "2018"
 description = "A web server that is fast!"

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -1,0 +1,23 @@
+## Environment Variables
+
+There some environment variables that Robyn looks out for. e.g. `ROBYN_URL` and `ROBYN_PORT`. 
+
+You can have a `robyn.env` file to load them automatically in your environment. 
+
+The server will check for the `robyn.env` file in the root of the project. If it is able to find one, it will parse the environment variables and the set your environment.
+
+e.g. structure
+
+```
+--project/
+  --robyn.env
+  --index.py
+  ...
+```
+
+Sample `robyn.env`
+
+```
+ROBYN_PORT=5000
+ROBYN_URL=127.0.0.1
+```

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -76,3 +76,15 @@ def dev_session():
     yield
     kill_process(process)
 
+@pytest.fixture(scope="session")
+def test_session():
+    os.environ["ROBYN_URL"] = "127.0.0.1"
+    os.environ["ROBYN_PORT"] = "8080"
+    current_file_path = pathlib.Path(__file__).parent.resolve()
+    base_routes = os.path.join(current_file_path, "./base_routes.py")
+    command = ["python3", base_routes, "--dev"]
+    process = spawn_process(command)
+    time.sleep(5)
+    yield
+    kill_process(process)
+

--- a/integration_tests/test_env_populator.py
+++ b/integration_tests/test_env_populator.py
@@ -13,19 +13,20 @@ path = pathlib.Path(__file__).parent
 @pytest.fixture
 def env_file():
     CONTENT = """ROBYN_PORT=8080 
-    ROBYN_URL=127.0.1.1"""
+    ROBYN_URL=127.0.0.1"""
     dir = path / "test_dir"
     env_file = dir / "robyn.env"
     env_file.write_text(CONTENT)
     yield
     env_file.unlink()
-    os.unsetenv("PORT")
+    os.unsetenv("ROBYN_PORT")
+    os.unsetenv("ROBYN_URL")
 
 # this tests if a connection can be made to the server with the correct port imported from the env file
-def test_env_population(dev_session, env_file):
+def test_env_population(test_session, env_file):
     dir = path / "test_dir"
-    env_file = dir / "robyn.env"
-    load_vars(variables = parser(config_path = env_file))
+    env_path = dir / "build"
+    load_vars(search_from=dir)
     PORT = os.environ['ROBYN_PORT'] 
     HOST = os.environ['ROBYN_URL']
     BASE_URL = f"http://{HOST}:{PORT}"

--- a/integration_tests/test_env_populator.py
+++ b/integration_tests/test_env_populator.py
@@ -14,19 +14,17 @@ path = pathlib.Path(__file__).parent
 def env_file():
     CONTENT = """ROBYN_PORT=8080 
     ROBYN_URL=127.0.0.1"""
-    dir = path / "test_dir"
-    env_file = dir / "robyn.env"
-    env_file.write_text(CONTENT)
+    env_path = path / "robyn.env"
+    env_path.write_text(CONTENT)
     yield
-    env_file.unlink()
+    env_path.unlink()
     os.unsetenv("ROBYN_PORT")
     os.unsetenv("ROBYN_URL")
 
 # this tests if a connection can be made to the server with the correct port imported from the env file
 def test_env_population(test_session, env_file):
-    dir = path / "test_dir"
-    env_path = dir / "build"
-    load_vars(search_from=dir)
+    env_path = path / "robyn.env"
+    load_vars(variables=parser(config_path=env_path))
     PORT = os.environ['ROBYN_PORT'] 
     HOST = os.environ['ROBYN_URL']
     BASE_URL = f"http://{HOST}:{PORT}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 name = "robyn"
-version = "0.17.5"
+version = "0.18.0"
 description = "A web server that is fast!"
 authors = ["Sanskar Jethi <sansyrox@gmail.com>"]
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -40,7 +40,7 @@ class Robyn:
         self.headers = []
         self.directories = []
         self.event_handlers = {}
-        load_vars(search_from=directory_path)
+        load_vars(root=directory_path)
         self._config_logger()
 
     def _add_route(self, route_type, endpoint, handler, const=False):

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -40,7 +40,7 @@ class Robyn:
         self.headers = []
         self.directories = []
         self.event_handlers = {}
-        load_vars(root=directory_path)
+        load_vars(project_root=directory_path)
         self._config_logger()
 
     def _add_route(self, route_type, endpoint, handler, const=False):

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -40,7 +40,7 @@ class Robyn:
         self.headers = []
         self.directories = []
         self.event_handlers = {}
-        load_vars()
+        load_vars(entry_point = directory_path)
         self._config_logger()
 
     def _add_route(self, route_type, endpoint, handler, const=False):

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -40,7 +40,7 @@ class Robyn:
         self.headers = []
         self.directories = []
         self.event_handlers = {}
-        load_vars(entry_point = directory_path)
+        load_vars(search_from=directory_path)
         self._config_logger()
 
     def _add_route(self, route_type, endpoint, handler, const=False):
@@ -105,6 +105,10 @@ class Robyn:
 
         :param port int: reperesents the port number at which the server is listening
         """
+
+        url = os.getenv("ROBYN_URL", "127.0.0.1")
+        port= int(os.getenv("ROBYN_PORT", "5000"))
+        
         def init_processpool(socket):
 
             process_pool = []

--- a/robyn/dev_event_handler.py
+++ b/robyn/dev_event_handler.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from watchdog.events import FileSystemEventHandler
 
@@ -7,11 +8,14 @@ class EventHandler(FileSystemEventHandler):
     def __init__(self, file_name) -> None:
         self.file_name = file_name
         self.processes = []
+        self.python_alias = "python3" if not sys.platform.startswith("win32") else "python"
+        self.shell = True if sys.platform.startswith("win32") else False
+        
 
     def start_server_first_time(self) -> None:
         if self.processes:
             raise Exception("Something wrong with the server")
-        self.processes.append(subprocess.Popen(["python3", self.file_name], start_new_session=False))
+        self.processes.append(subprocess.Popen([self.python_alias, self.file_name], shell = self.shell, start_new_session=False))
 
     def on_any_event(self, event) -> None:
         """
@@ -22,5 +26,5 @@ class EventHandler(FileSystemEventHandler):
 
         if len(self.processes) > 0:
             for process in self.processes:
-                process.terminate()
-        self.processes.append(subprocess.Popen(["python3", self.file_name], start_new_session=False))
+                process.terminate()         
+        self.processes.append(subprocess.Popen([self.python_alias, self.file_name], shell = self.shell, start_new_session=False))

--- a/robyn/env_populator.py
+++ b/robyn/env_populator.py
@@ -3,13 +3,6 @@ import logging
 from pathlib import Path
 
 
-
-# # Path to the root of the project
-# ROOT_DIR = Path(__file__)
-
-# # Path to the environment variables
-# CONFIG_PATH = ROOT_DIR / 'robyn.env'
-
 #set the logger that will log the environment variables imported from robyn.env and the ones already set
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -17,28 +10,29 @@ logging.basicConfig(level=logging.INFO)
 # detect the robyn.env file in the project
 def find(name, path):
     for root, dirs, files in os.walk(path, topdown=False):
-        if name in files:
+        if name in files:            
             return Path(os.path.join(root, name))
 
 # parse the configuration file returning a list of tuples (key, value) containing the environment variables
-def parser(config_path=None, entry_point=None):
+def parser(entry_point=None):
     """Parse the configuration file"""
-    if config_path is None:
+    if entry_point is not None:
         config_path = find('robyn.env', entry_point)
-    if config_path.exists():
-        with open(config_path, 'r') as f:
-            for line in f:
-                if line.startswith('#'):
-                    continue
-                yield line.strip().split('=')  
+
+        if config_path.exists():
+            with open(config_path, 'r') as f:
+                for line in f:
+                    if line.startswith('#'):
+                        continue
+                    yield line.strip().split('=')  
 
 
 # check for the environment variables set in cli and if not set them
-def load_vars(variables = None, env_path=None, entry_point=None):
+def load_vars(variables = None, search_from=None):
     """Main function"""
     
     if variables is None:
-        variables = parser(config_path = env_path, entry_point=entry_point)
+        variables = parser(entry_point=search_from)
 
     for var in variables:
         if var[0] in os.environ:

--- a/robyn/env_populator.py
+++ b/robyn/env_populator.py
@@ -11,11 +11,10 @@ logging.basicConfig(level=logging.INFO)
 
 # parse the configuration file returning a list of tuples (key, value) containing the environment variables
 def parser(config_path=None, project_root = None):
-    """Find robyn.env file in root of the project"""
+    """Find robyn.env file in root of the project and parse it """
     if config_path is None:
         config_path = Path(project_root) / "robyn.env"
 
-    """Parse the configuration file"""
     if config_path.exists():
         with open(config_path, 'r') as f:
             for line in f:

--- a/robyn/env_populator.py
+++ b/robyn/env_populator.py
@@ -1,3 +1,4 @@
+from distutils.command.config import config
 import os 
 import logging
 from pathlib import Path
@@ -7,32 +8,28 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-# detect the robyn.env file in the project
-def find(name, path):
-    for root, dirs, files in os.walk(path, topdown=False):
-        if name in files:            
-            return Path(os.path.join(root, name))
 
 # parse the configuration file returning a list of tuples (key, value) containing the environment variables
-def parser(entry_point=None):
-    """Parse the configuration file"""
-    if entry_point is not None:
-        config_path = find('robyn.env', entry_point)
+def parser(config_path=None, project_root = None):
+    """Find robyn.env file in root of the project"""
+    if config_path is None:
+        config_path = Path(project_root) / "robyn.env"
 
-        if config_path.exists():
-            with open(config_path, 'r') as f:
-                for line in f:
-                    if line.startswith('#'):
-                        continue
-                    yield line.strip().split('=')  
+    """Parse the configuration file"""
+    if config_path.exists():
+        with open(config_path, 'r') as f:
+            for line in f:
+                if line.startswith('#'):
+                    continue
+                yield line.strip().split('=')  
 
 
 # check for the environment variables set in cli and if not set them
-def load_vars(variables = None, search_from=None):
+def load_vars(variables = None, root = None):
     """Main function"""
     
     if variables is None:
-        variables = parser(entry_point=search_from)
+        variables = parser(project_root=root)
 
     for var in variables:
         if var[0] in os.environ:

--- a/robyn/env_populator.py
+++ b/robyn/env_populator.py
@@ -4,19 +4,27 @@ from pathlib import Path
 
 
 
-# Path to the root of the project
-ROOT_DIR = Path(__file__).parent.parent
+# # Path to the root of the project
+# ROOT_DIR = Path(__file__)
 
-# Path to the environment variables
-CONFIG_PATH = ROOT_DIR / 'robyn.env'
+# # Path to the environment variables
+# CONFIG_PATH = ROOT_DIR / 'robyn.env'
 
 #set the logger that will log the environment variables imported from robyn.env and the ones already set
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+# detect the robyn.env file in the project
+def find(name, path):
+    for root, dirs, files in os.walk(path, topdown=False):
+        if name in files:
+            return Path(os.path.join(root, name))
+
 # parse the configuration file returning a list of tuples (key, value) containing the environment variables
-def parser(config_path=CONFIG_PATH):
+def parser(config_path=None, entry_point=None):
     """Parse the configuration file"""
+    if config_path is None:
+        config_path = find('robyn.env', entry_point)
     if config_path.exists():
         with open(config_path, 'r') as f:
             for line in f:
@@ -26,11 +34,11 @@ def parser(config_path=CONFIG_PATH):
 
 
 # check for the environment variables set in cli and if not set them
-def load_vars(variables = None):
+def load_vars(variables = None, env_path=None, entry_point=None):
     """Main function"""
     
     if variables is None:
-        variables = parser()
+        variables = parser(config_path = env_path, entry_point=entry_point)
 
     for var in variables:
         if var[0] in os.environ:

--- a/robyn/env_populator.py
+++ b/robyn/env_populator.py
@@ -24,11 +24,11 @@ def parser(config_path=None, project_root = None):
 
 
 # check for the environment variables set in cli and if not set them
-def load_vars(variables = None, root = None):
+def load_vars(variables = None, project_root = None):
     """Main function"""
     
     if variables is None:
-        variables = parser(project_root=root)
+        variables = parser(project_root=project_root)
 
     for var in variables:
         if var[0] in os.environ:

--- a/src/server.rs
+++ b/src/server.rs
@@ -454,9 +454,8 @@ async fn index(
         }
     };
 
-    match middleware_router.get_route("AFTER_REQUEST", req.uri().path()) {
-        Some(((handler_function, number_of_params), route_params)) => {
-            let x = handle_http_middleware_request(
+    if let Some(((handler_function, number_of_params), route_params)) = middleware_router.get_route("AFTER_REQUEST", req.uri().path()) {
+        let x = handle_http_middleware_request(
                 handler_function,
                 number_of_params,
                 &headers_dup,
@@ -467,8 +466,6 @@ async fn index(
             )
             .await;
             debug!("{:?}", x);
-        }
-        None => {}
     };
 
     response


### PR DESCRIPTION
**Description**

This PR fixes an issue with detecting robyn.env in a project, if the server is started somewhere in a nested file or the user placed robyn.env somewhere different than expected of him robyn.env won't be found and thus i added a file detector function that starts searching from an entry point where robyn server started and goes from the bottom up in the directories searching for robyn.env 

