### PR TITLE
fix: replaced match with if let

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -454,9 +454,8 @@ async fn index(
         }
     };
 
-    match middleware_router.get_route("AFTER_REQUEST", req.uri().path()) {
-        Some(((handler_function, number_of_params), route_params)) => {
-            let x = handle_http_middleware_request(
+    if let Some(((handler_function, number_of_params), route_params)) = middleware_router.get_route("AFTER_REQUEST", req.uri().path()) {
+        let x = handle_http_middleware_request(
                 handler_function,
                 number_of_params,
                 &headers_dup,
@@ -467,8 +466,6 @@ async fn index(
             )
             .await;
             debug!("{:?}", x);
-        }
-        None => {}
     };
 
     response


### PR DESCRIPTION
**Description**

Replaced "match" with "if let" to eliminate the clippy message. This has been built and tested.

This PR fixes #265 

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->