### PR TITLE
`SocketHeld::new` refactor

### DIFF
--- a/src/shared_socket.rs
+++ b/src/shared_socket.rs
@@ -13,26 +13,14 @@ pub struct SocketHeld {
 #[pymethods]
 impl SocketHeld {
     #[new]
-    #[cfg(not(target_os = "windows"))]
-    pub fn new(address: String, port: i32) -> PyResult<SocketHeld> {
-        let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
-        let address: SocketAddr = format!("{}:{}", address, port).parse()?;
-        debug!("{}", address);
-        socket.set_reuse_port(true)?;
-        socket.set_reuse_address(true)?;
-        socket.bind(&address.into())?;
-        socket.listen(1024)?;
-
-        Ok(SocketHeld { socket })
-    }
-
-    #[new]
-    #[cfg(target_os = "windows")]
     pub fn new(address: String, port: i32) -> PyResult<SocketHeld> {
         let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
         let address: SocketAddr = format!("{}:{}", address, port).parse()?;
         debug!("{}", address);
         // reuse port is not available on windows
+        #[cfg(not(target_os = "windows"))]
+        socket.set_reuse_port(true)?;
+
         socket.set_reuse_address(true)?;
         socket.bind(&address.into())?;
         socket.listen(1024)?;


### PR DESCRIPTION
**Description**

Reduce `SocketHeld::new` verbose code. And make it support both ipv4 and ipv6.

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->