### PR TITLE
fix config of port and url

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -102,16 +102,18 @@ class Robyn:
 
     def shutdown_handler(self, handler: Callable) -> None:
         self._add_event_handler(Events.SHUTDOWN, handler)
-
-    def start(self, url: str = "127.0.0.1", port: int = 5000):
+    
+    def start(self, url=None, port=None):
         """
         Starts the server
 
         :param port int: reperesents the port number at which the server is listening
         """
-
-        url = os.getenv("ROBYN_URL", "127.0.0.1")
-        port = int(os.getenv("ROBYN_PORT", "5000"))
+        
+        if url is None:
+        	url = os.getenv("ROBYN_URL", "127.0.0.1")
+        if port is None:
+        	port = int(os.getenv("ROBYN_PORT", "5000"))
 
         def init_processpool(socket):
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -103,17 +103,15 @@ class Robyn:
     def shutdown_handler(self, handler: Callable) -> None:
         self._add_event_handler(Events.SHUTDOWN, handler)
 
-    def start(self, url: str | None = None, port: int | None = None):
+    def start(self, url: str = "127.0.0.1", port: int = 5000):
         """
         Starts the server
 
         :param port int: reperesents the port number at which the server is listening
         """
 
-        if url is None:
-            url = os.getenv("ROBYN_URL", "127.0.0.1")
-        if port is None:
-            port = int(os.getenv("ROBYN_PORT", "5000"))
+        url = os.getenv("ROBYN_URL", url)
+        port = int(os.getenv("ROBYN_PORT", port))
 
         def init_processpool(socket):
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -102,18 +102,18 @@ class Robyn:
 
     def shutdown_handler(self, handler: Callable) -> None:
         self._add_event_handler(Events.SHUTDOWN, handler)
-    
-    def start(self, url=None, port=None):
+
+    def start(self, url: str | None = None, port: int | None = None):
         """
         Starts the server
 
         :param port int: reperesents the port number at which the server is listening
         """
-        
+
         if url is None:
-        	url = os.getenv("ROBYN_URL", "127.0.0.1")
+            url = os.getenv("ROBYN_URL", "127.0.0.1")
         if port is None:
-        	port = int(os.getenv("ROBYN_PORT", "5000"))
+            port = int(os.getenv("ROBYN_PORT", "5000"))
 
         def init_processpool(socket):
 


### PR DESCRIPTION
**Description**

This PR fixes an issue with configuring port and url. In #292, you change code to fix port and url each 500 and 127.0.01 when robyn.env doesn't exist.
So, I changed url and port that is the parameter of app.start() method to optional parameter. 
Then, you can use app.start() without parameter, and you can use parameter port and url ignoring robyn.env.

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->