### PR TITLE
Router refactor

### DIFF
--- a/src/routers/const_router.rs
+++ b/src/routers/const_router.rs
@@ -13,7 +13,6 @@ use actix_web::http::Method;
 
 use anyhow::{Error, Result};
 
-use super::RouteType;
 use super::Router;
 
 type RouteMap = RwLock<matchit::Router<String>>;
@@ -59,13 +58,8 @@ impl Router<String, Method> for ConstRouter {
         Ok(())
     }
 
-    fn get_route(
-        &self,
-        route_method: RouteType<Method>,
-        route: &str, // check for the route method here
-    ) -> Option<String> {
-        // need to split this function in multiple smaller functions
-        let table = self.routes.get(&route_method.0)?;
+    fn get_route(&self, route_method: Method, route: &str) -> Option<String> {
+        let table = self.routes.get(&route_method)?;
         let route_map = table.read().ok()?;
 
         match route_map.at(route) {

--- a/src/routers/const_router.rs
+++ b/src/routers/const_router.rs
@@ -1,125 +1,109 @@
+use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::RwLock;
 // pyo3 modules
 use crate::executors::execute_function;
+use anyhow::Context;
 use log::debug;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
 use actix_web::http::Method;
-use matchit::Router;
 
-use anyhow::{bail, Error, Result};
+use anyhow::{Error, Result};
+
+use super::RouteType;
+use super::Router;
+
+type RouteMap = RwLock<matchit::Router<String>>;
 
 /// Contains the thread safe hashmaps of different routes
-
 pub struct ConstRouter {
-    get_routes: Arc<RwLock<Router<String>>>,
-    post_routes: Arc<RwLock<Router<String>>>,
-    put_routes: Arc<RwLock<Router<String>>>,
-    delete_routes: Arc<RwLock<Router<String>>>,
-    patch_routes: Arc<RwLock<Router<String>>>,
-    head_routes: Arc<RwLock<Router<String>>>,
-    options_routes: Arc<RwLock<Router<String>>>,
-    connect_routes: Arc<RwLock<Router<String>>>,
-    trace_routes: Arc<RwLock<Router<String>>>,
+    routes: HashMap<Method, Arc<RouteMap>>,
 }
 
-impl ConstRouter {
-    pub fn new() -> Self {
-        Self {
-            get_routes: Arc::new(RwLock::new(Router::new())),
-            post_routes: Arc::new(RwLock::new(Router::new())),
-            put_routes: Arc::new(RwLock::new(Router::new())),
-            delete_routes: Arc::new(RwLock::new(Router::new())),
-            patch_routes: Arc::new(RwLock::new(Router::new())),
-            head_routes: Arc::new(RwLock::new(Router::new())),
-            options_routes: Arc::new(RwLock::new(Router::new())),
-            connect_routes: Arc::new(RwLock::new(Router::new())),
-            trace_routes: Arc::new(RwLock::new(Router::new())),
-        }
-    }
-
-    #[inline]
-    fn get_relevant_map(&self, route: Method) -> Option<Arc<RwLock<Router<String>>>> {
-        match route {
-            Method::GET => Some(self.get_routes.clone()),
-            Method::POST => Some(self.post_routes.clone()),
-            Method::PUT => Some(self.put_routes.clone()),
-            Method::PATCH => Some(self.patch_routes.clone()),
-            Method::DELETE => Some(self.delete_routes.clone()),
-            Method::HEAD => Some(self.head_routes.clone()),
-            Method::OPTIONS => Some(self.options_routes.clone()),
-            Method::CONNECT => Some(self.connect_routes.clone()),
-            Method::TRACE => Some(self.trace_routes.clone()),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    fn get_relevant_map_str(&self, route: &str) -> Option<Arc<RwLock<Router<String>>>> {
-        if route != "WS" {
-            let method = match Method::from_bytes(route.as_bytes()) {
-                Ok(res) => res,
-                Err(_) => return None,
-            };
-
-            self.get_relevant_map(method)
-        } else {
-            None
-        }
-    }
-
-    /// Checks if the functions is an async function
-    /// Inserts them in the router according to their nature(CoRoutine/SyncFunction)
+impl Router<String, Method> for ConstRouter {
     /// Doesn't allow query params/body/etc as variables cannot be "memoized"/"const"ified
-    pub fn add_route(
+    fn add_route(
         &self,
         route_type: &str, // we can just have route type as WS
         route: &str,
         function: Py<PyAny>,
         is_async: bool,
         number_of_params: u8,
-        event_loop: &PyAny,
+        event_loop: Option<&PyAny>,
     ) -> Result<(), Error> {
-        let table = match self.get_relevant_map_str(route_type) {
-            Some(table) => table,
-            None => bail!("No relevant map"),
-        };
+        let table = self
+            .get_relevant_map_str(route_type)
+            .context("No relevant map")?
+            .clone();
+
         let route = route.to_string();
+        let event_loop =
+            event_loop.context("Event loop must be provided to add a route to the const router")?;
+
         pyo3_asyncio::tokio::run_until_complete(event_loop, async move {
             let output = execute_function(function, number_of_params, is_async)
                 .await
                 .unwrap();
             debug!("This is the result of the output {:?}", output);
             table
-                .clone()
                 .write()
                 .unwrap()
                 .insert(route, output.get("body").unwrap().to_string())
                 .unwrap();
-
             Ok(())
-        })
-        .unwrap();
+        })?;
 
         Ok(())
     }
 
-    // Checks if the functions is an async function
-    // Inserts them in the router according to their nature(CoRoutine/SyncFunction)
-    pub fn get_route(
+    fn get_route(
         &self,
-        route_method: Method,
+        route_method: RouteType<Method>,
         route: &str, // check for the route method here
     ) -> Option<String> {
         // need to split this function in multiple smaller functions
-        let table = self.get_relevant_map(route_method)?;
+        let table = self.routes.get(&route_method.0)?;
         let route_map = table.read().ok()?;
 
         match route_map.at(route) {
             Ok(res) => Some(res.value.clone()),
             Err(_) => None,
+        }
+    }
+}
+
+impl ConstRouter {
+    pub fn new() -> Self {
+        let mut routes = HashMap::new();
+        routes.insert(Method::GET, Arc::new(RwLock::new(matchit::Router::new())));
+        routes.insert(Method::POST, Arc::new(RwLock::new(matchit::Router::new())));
+        routes.insert(Method::PUT, Arc::new(RwLock::new(matchit::Router::new())));
+        routes.insert(
+            Method::DELETE,
+            Arc::new(RwLock::new(matchit::Router::new())),
+        );
+        routes.insert(Method::PATCH, Arc::new(RwLock::new(matchit::Router::new())));
+        routes.insert(Method::HEAD, Arc::new(RwLock::new(matchit::Router::new())));
+        routes.insert(
+            Method::OPTIONS,
+            Arc::new(RwLock::new(matchit::Router::new())),
+        );
+        routes.insert(
+            Method::CONNECT,
+            Arc::new(RwLock::new(matchit::Router::new())),
+        );
+        routes.insert(Method::TRACE, Arc::new(RwLock::new(matchit::Router::new())));
+        Self { routes }
+    }
+
+    #[inline]
+    fn get_relevant_map_str(&self, route: &str) -> Option<&Arc<RouteMap>> {
+        match route {
+            "WS" => None,
+            _ => self.routes.get(&Method::from_str(route).ok()?),
         }
     }
 }

--- a/src/routers/http_router.rs
+++ b/src/routers/http_router.rs
@@ -15,11 +15,11 @@ use super::Router;
 type RouteMap = RwLock<MatchItRouter<(PyFunction, u8)>>;
 
 /// Contains the thread safe hashmaps of different routes
-pub struct DynRouter {
+pub struct HttpRouter {
     routes: HashMap<Method, RouteMap>,
 }
 
-impl Router<((PyFunction, u8), HashMap<String, String>), Method> for DynRouter {
+impl Router<((PyFunction, u8), HashMap<String, String>), Method> for HttpRouter {
     fn add_route(
         &self,
         route_type: &str, // We can just have route type as WS
@@ -65,7 +65,7 @@ impl Router<((PyFunction, u8), HashMap<String, String>), Method> for DynRouter {
     }
 }
 
-impl DynRouter {
+impl HttpRouter {
     pub fn new() -> Self {
         let mut routes = HashMap::new();
         routes.insert(Method::GET, RwLock::new(MatchItRouter::new()));

--- a/src/routers/middleware_router.rs
+++ b/src/routers/middleware_router.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Error, Result};
 
 use crate::routers::types::MiddlewareRoute;
 
-use super::{RouteType, Router};
+use super::Router;
 
 type RouteMap = RwLock<matchit::Router<(PyFunction, u8)>>;
 
@@ -34,8 +34,6 @@ impl MiddlewareRouter {
 }
 
 impl Router<((PyFunction, u8), HashMap<String, String>), MiddlewareRoute> for MiddlewareRouter {
-    // Checks if the functions is an async function
-    // Inserts them in the router according to their nature(CoRoutine/SyncFunction)
     fn add_route(
         &self,
         route_type: &str,
@@ -65,10 +63,10 @@ impl Router<((PyFunction, u8), HashMap<String, String>), MiddlewareRoute> for Mi
 
     fn get_route(
         &self,
-        route_method: RouteType<MiddlewareRoute>,
+        route_method: MiddlewareRoute,
         route: &str,
     ) -> Option<((PyFunction, u8), HashMap<String, String>)> {
-        let table = self.routes.get(&route_method.0)?;
+        let table = self.routes.get(&route_method)?;
 
         let table_lock = table.read().ok()?;
         let res = table_lock.at(route).ok()?;

--- a/src/routers/mod.rs
+++ b/src/routers/mod.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use pyo3::{Py, PyAny};
 
 pub mod const_router;
+pub mod http_router;
 pub mod middleware_router;
-pub mod router;
 pub mod types;
 pub mod web_socket_router;
 

--- a/src/routers/mod.rs
+++ b/src/routers/mod.rs
@@ -1,5 +1,28 @@
+use anyhow::Result;
+use pyo3::{Py, PyAny};
+
 pub mod const_router;
 pub mod middleware_router;
 pub mod router;
 pub mod types;
 pub mod web_socket_router;
+
+pub struct RouteType<T>(pub T);
+
+pub trait Router<T, U> {
+    /// Checks if the functions is an async function
+    /// Inserts them in the router according to their nature(CoRoutine/SyncFunction)
+    fn add_route(
+        &self,
+        route_type: &str,
+        route: &str,
+        handler: Py<PyAny>,
+        is_async: bool,
+        number_of_params: u8,
+        event_loop: Option<&PyAny>,
+    ) -> Result<()>;
+
+    /// Checks if the functions is an async function
+    /// Inserts them in the router according to their nature(CoRoutine/SyncFunction)
+    fn get_route(&self, route_method: RouteType<U>, route: &str) -> Option<T>;
+}

--- a/src/routers/mod.rs
+++ b/src/routers/mod.rs
@@ -7,8 +7,6 @@ pub mod router;
 pub mod types;
 pub mod web_socket_router;
 
-pub struct RouteType<T>(pub T);
-
 pub trait Router<T, U> {
     /// Checks if the functions is an async function
     /// Inserts them in the router according to their nature(CoRoutine/SyncFunction)
@@ -22,7 +20,6 @@ pub trait Router<T, U> {
         event_loop: Option<&PyAny>,
     ) -> Result<()>;
 
-    /// Checks if the functions is an async function
-    /// Inserts them in the router according to their nature(CoRoutine/SyncFunction)
-    fn get_route(&self, route_method: RouteType<U>, route: &str) -> Option<T>;
+    /// Retrieve the correct function from the previously inserted routes
+    fn get_route(&self, route_method: U, route: &str) -> Option<T>;
 }

--- a/src/routers/router.rs
+++ b/src/routers/router.rs
@@ -10,7 +10,7 @@ use matchit::Router as MatchItRouter;
 
 use anyhow::{Context, Result};
 
-use super::{RouteType, Router};
+use super::Router;
 
 type RouteMap = RwLock<MatchItRouter<(PyFunction, u8)>>;
 
@@ -49,11 +49,10 @@ impl Router<((PyFunction, u8), HashMap<String, String>), Method> for DynRouter {
 
     fn get_route(
         &self,
-        route_method: RouteType<Method>,
+        route_method: Method,
         route: &str,
     ) -> Option<((PyFunction, u8), HashMap<String, String>)> {
-        // need to split this function in multiple smaller functions
-        let table = self.routes.get(&route_method.0)?;
+        let table = self.routes.get(&route_method)?;
 
         let table_lock = table.read().ok()?;
         let res = table_lock.at(route).ok()?;

--- a/src/routers/types.rs
+++ b/src/routers/types.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum MiddlewareRoute {
     BeforeRequest,
     AfterRequest,

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,7 @@ use crate::request_handler::{handle_http_middleware_request, handle_http_request
 use crate::routers::const_router::ConstRouter;
 use crate::routers::Router;
 
-use crate::routers::router::DynRouter;
+use crate::routers::http_router::HttpRouter;
 use crate::routers::types::MiddlewareRoute;
 use crate::routers::{middleware_router::MiddlewareRouter, web_socket_router::WebSocketRouter};
 use crate::shared_socket::SocketHeld;
@@ -44,7 +44,7 @@ struct Directory {
 
 #[pyclass]
 pub struct Server {
-    router: Arc<DynRouter>,
+    router: Arc<HttpRouter>,
     const_router: Arc<ConstRouter>,
     websocket_router: Arc<WebSocketRouter>,
     middleware_router: Arc<MiddlewareRouter>,
@@ -59,7 +59,7 @@ impl Server {
     #[new]
     pub fn new() -> Self {
         Self {
-            router: Arc::new(DynRouter::new()),
+            router: Arc::new(HttpRouter::new()),
             const_router: Arc::new(ConstRouter::new()),
             websocket_router: Arc::new(WebSocketRouter::new()),
             middleware_router: Arc::new(MiddlewareRouter::new()),
@@ -158,7 +158,7 @@ impl Server {
                         app = app.route(
                             &route.clone(),
                             web::get().to(
-                                move |_router: web::Data<Arc<DynRouter>>,
+                                move |_router: web::Data<Arc<HttpRouter>>,
                                       _global_headers: web::Data<Arc<Headers>>,
                                       stream: web::Payload,
                                       req: HttpRequest| {
@@ -174,7 +174,7 @@ impl Server {
                     }
 
                     app.default_service(web::route().to(
-                        move |router: web::Data<Arc<DynRouter>>,
+                        move |router: web::Data<Arc<HttpRouter>>,
                               const_router: web::Data<Arc<ConstRouter>>,
                               middleware_router: web::Data<Arc<MiddlewareRouter>>,
                               global_headers,
@@ -367,7 +367,7 @@ async fn merge_headers(
 /// This is our service handler. It receives a Request, routes on it
 /// path, and returns a Future of a Response.
 async fn index(
-    router: web::Data<Arc<DynRouter>>,
+    router: web::Data<Arc<HttpRouter>>,
     const_router: web::Data<Arc<ConstRouter>>,
     middleware_router: web::Data<Arc<MiddlewareRouter>>,
     global_headers: web::Data<Arc<Headers>>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -86,10 +86,7 @@ impl Server {
             return Ok(());
         }
 
-        let borrow = socket.try_borrow_mut()?;
-        let held_socket: &SocketHeld = &*borrow;
-
-        let raw_socket = held_socket.get_socket();
+        let raw_socket = socket.try_borrow_mut()?.get_socket();
 
         let router = self.router.clone();
         let const_router = self.const_router.clone();


### PR DESCRIPTION
**Description**

This PR refactors the `routers` module of the Rust part of Robyn.
I noticed some improvements could be made there so here is my take on it.

Noticeable changes:
- Rename `Router` to `DynRouter`
- Introduce a `Router` trait to unify the behavior of `ConstRouter`, `DynRouter`, and `MiddlewareRouter`
- Get rid of the `get_relevant_map` methods (mapping is directly done at structure creation)
- Some parts of the code were made less verbose

I tried to keep the same logic as before. I think this could pave the way for further performance improvements for the router  :slightly_smiling_face: 

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->