### PR TITLE
Various improvements around the index method

### DIFF
--- a/src/io_helpers/mod.rs
+++ b/src/io_helpers/mod.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
-
 use std::fs::File;
 use std::io::Read;
 
 use actix_web::HttpResponseBuilder;
+use anyhow::Result;
 
 // this should be something else
 // probably inside the submodule of the http router
 #[inline]
-pub fn apply_headers(response: &mut HttpResponseBuilder, headers: HashMap<String, String>) {
+pub fn apply_headers(response: &mut HttpResponseBuilder, headers: &HashMap<String, String>) {
     for (key, val) in (headers).iter() {
         response.insert_header((key.clone(), val.clone()));
     }
@@ -21,7 +21,7 @@ pub fn apply_headers(response: &mut HttpResponseBuilder, headers: HashMap<String
 /// * `file_path` - The file path that we want the function to read
 ///
 // ideally this should be async
-pub fn read_file(file_path: &str) -> Result<String, Box<dyn std::error::Error>> {
+pub fn read_file(file_path: &str) -> Result<String> {
     let mut file = File::open(file_path)?;
     let mut buf = vec![];
     file.read_to_end(&mut buf)?;

--- a/src/routers/const_router.rs
+++ b/src/routers/const_router.rs
@@ -6,6 +6,7 @@ use std::sync::RwLock;
 use crate::executors::execute_function;
 use anyhow::Context;
 use log::debug;
+use matchit::Router as MatchItRouter;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
@@ -15,7 +16,7 @@ use anyhow::{Error, Result};
 
 use super::Router;
 
-type RouteMap = RwLock<matchit::Router<String>>;
+type RouteMap = RwLock<MatchItRouter<String>>;
 
 /// Contains the thread safe hashmaps of different routes
 pub struct ConstRouter {
@@ -58,8 +59,8 @@ impl Router<String, Method> for ConstRouter {
         Ok(())
     }
 
-    fn get_route(&self, route_method: Method, route: &str) -> Option<String> {
-        let table = self.routes.get(&route_method)?;
+    fn get_route(&self, route_method: &Method, route: &str) -> Option<String> {
+        let table = self.routes.get(route_method)?;
         let route_map = table.read().ok()?;
 
         match route_map.at(route) {
@@ -72,24 +73,15 @@ impl Router<String, Method> for ConstRouter {
 impl ConstRouter {
     pub fn new() -> Self {
         let mut routes = HashMap::new();
-        routes.insert(Method::GET, Arc::new(RwLock::new(matchit::Router::new())));
-        routes.insert(Method::POST, Arc::new(RwLock::new(matchit::Router::new())));
-        routes.insert(Method::PUT, Arc::new(RwLock::new(matchit::Router::new())));
-        routes.insert(
-            Method::DELETE,
-            Arc::new(RwLock::new(matchit::Router::new())),
-        );
-        routes.insert(Method::PATCH, Arc::new(RwLock::new(matchit::Router::new())));
-        routes.insert(Method::HEAD, Arc::new(RwLock::new(matchit::Router::new())));
-        routes.insert(
-            Method::OPTIONS,
-            Arc::new(RwLock::new(matchit::Router::new())),
-        );
-        routes.insert(
-            Method::CONNECT,
-            Arc::new(RwLock::new(matchit::Router::new())),
-        );
-        routes.insert(Method::TRACE, Arc::new(RwLock::new(matchit::Router::new())));
+        routes.insert(Method::GET, Arc::new(RwLock::new(MatchItRouter::new())));
+        routes.insert(Method::POST, Arc::new(RwLock::new(MatchItRouter::new())));
+        routes.insert(Method::PUT, Arc::new(RwLock::new(MatchItRouter::new())));
+        routes.insert(Method::DELETE, Arc::new(RwLock::new(MatchItRouter::new())));
+        routes.insert(Method::PATCH, Arc::new(RwLock::new(MatchItRouter::new())));
+        routes.insert(Method::HEAD, Arc::new(RwLock::new(MatchItRouter::new())));
+        routes.insert(Method::OPTIONS, Arc::new(RwLock::new(MatchItRouter::new())));
+        routes.insert(Method::CONNECT, Arc::new(RwLock::new(MatchItRouter::new())));
+        routes.insert(Method::TRACE, Arc::new(RwLock::new(MatchItRouter::new())));
         Self { routes }
     }
 

--- a/src/routers/http_router.rs
+++ b/src/routers/http_router.rs
@@ -49,10 +49,10 @@ impl Router<((PyFunction, u8), HashMap<String, String>), Method> for HttpRouter 
 
     fn get_route(
         &self,
-        route_method: Method,
+        route_method: &Method,
         route: &str,
     ) -> Option<((PyFunction, u8), HashMap<String, String>)> {
-        let table = self.routes.get(&route_method)?;
+        let table = self.routes.get(route_method)?;
 
         let table_lock = table.read().ok()?;
         let res = table_lock.at(route).ok()?;

--- a/src/routers/mod.rs
+++ b/src/routers/mod.rs
@@ -21,5 +21,5 @@ pub trait Router<T, U> {
     ) -> Result<()>;
 
     /// Retrieve the correct function from the previously inserted routes
-    fn get_route(&self, route_method: U, route: &str) -> Option<T>;
+    fn get_route(&self, route_method: &U, route: &str) -> Option<T>;
 }


### PR DESCRIPTION
**Description**

Hello, I'm back with a new suggestion for the Rust code of Robyn.
I tried to simplify the code around the `index` function in `server.rs`:
- Removed unnecessary `Rc<RefCell<>>`
- Removed some `clone()` calls (this is mostly possible due to the use of the `to_object` method, which takes a reference to the object, instead of the `into_py` method which takes ownership of the object)
- Simplified some chunks of code

Let me know if this is ok for you :slightly_smiling_face: 