### PR TITLE
fix: factorizing code

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -14,7 +14,7 @@ from robyn.events import Events
 from robyn.log_colors import Colors
 from robyn.processpool import spawn_process
 from robyn.responses import jsonify, static_file
-from robyn.robyn import SocketHeld
+from robyn.robyn import FunctionInfo, SocketHeld
 from robyn.router import MiddlewareRouter, Router, WebSocketRouter
 from robyn.ws import WS
 from robyn.env_populator import load_vars
@@ -89,13 +89,13 @@ class Robyn:
     def add_web_socket(self, endpoint: str, ws: WS) -> None:
         self.web_socket_router.add_route(endpoint, ws)
 
-    def _add_event_handler(self, event_type: Events, handler) -> None:
+    def _add_event_handler(self, event_type: Events, handler: Callable) -> None:
         logger.debug(f"Add event {event_type} handler")
         if event_type not in {Events.STARTUP, Events.SHUTDOWN}:
             return
 
         is_async = asyncio.iscoroutinefunction(handler)
-        self.event_handlers[event_type] = (handler, is_async)
+        self.event_handlers[event_type] = FunctionInfo(handler, is_async, 0)
 
     def startup_handler(self, handler: Callable) -> None:
         self._add_event_handler(Events.STARTUP, handler)

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -43,7 +43,7 @@ class Robyn:
         load_vars(project_root=directory_path)
         self._config_logger()
 
-    def _add_route(self, route_type, endpoint, handler, const=False):
+    def _add_route(self, route_type, endpoint, handler, is_const=False):
         """
         [This is base handler for all the decorators]
 
@@ -54,7 +54,7 @@ class Robyn:
 
         """ We will add the status code here only
         """
-        return self.router.add_route(route_type, endpoint, handler, const)
+        return self.router.add_route(route_type, endpoint, handler, is_const)
 
     def before_request(self, endpoint: str) -> Callable[..., None]:
         """

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -67,8 +67,8 @@ def spawn_process(
         server.add_header(key, val)
 
     for route in routes:
-        route_type, endpoint, function, const = route
-        server.add_route(route_type, endpoint, function, const)
+        route_type, endpoint, function, is_const = route
+        server.add_route(route_type, endpoint, function, is_const)
 
     for route in middlewares:
         route_type, endpoint, function = route

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -33,7 +33,7 @@ class Server:
         route_type: str,
         route: str,
         function: FunctionInfo,
-        const: bool,
+        is_const: bool,
     ) -> None:
         pass
     def add_middleware_route(

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import dataclass
 
 from typing import Callable, Optional
 
@@ -8,9 +9,11 @@ class SocketHeld:
     def try_clone(self) -> SocketHeld:
         pass
 
+@dataclass
 class FunctionInfo:
-    def __init__(self, function: Callable, is_async: bool, number_of_params: int):
-        pass
+    function: Callable
+    is_async: bool
+    number_of_params: int
 
 class Server:
     def __init__(self) -> None:

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional
 
 class SocketHeld:
     def __init__(self, url: str, port: int):
         pass
     def try_clone(self) -> SocketHeld:
+        pass
+
+class FunctionInfo:
+    def __init__(self, function: Callable, is_async: bool, number_of_params: int):
         pass
 
 class Server:
@@ -25,9 +29,7 @@ class Server:
         self,
         route_type: str,
         route: str,
-        handler: Callable,
-        is_async: bool,
-        number_of_params: int,
+        function: FunctionInfo,
         const: bool,
     ) -> None:
         pass
@@ -35,21 +37,19 @@ class Server:
         self,
         route_type: str,
         route: str,
-        handler: Callable,
-        is_async: bool,
-        number_of_params: int,
+        function: FunctionInfo,
     ) -> None:
         pass
-    def add_startup_handler(self, handler: Callable, is_async: bool) -> None:
+    def add_startup_handler(self, function: FunctionInfo) -> None:
         pass
-    def add_shutdown_handler(self, handler: Callable, is_async: bool) -> None:
+    def add_shutdown_handler(self, function: FunctionInfo) -> None:
         pass
     def add_web_socket_route(
         self,
         route: str,
-        connect_route: Tuple[Callable, bool, int],
-        close_route: Tuple[Callable, bool, int],
-        message_route: Tuple[Callable, bool, int],
+        connect_route: FunctionInfo,
+        close_route: FunctionInfo,
+        message_route: FunctionInfo,
     ) -> None:
         pass
     def start(self, socket: SocketHeld, workers: int) -> None:

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -41,7 +41,7 @@ class Router(BaseRouter):
         return response
 
     def add_route(
-        self, route_type: str, endpoint: str, handler: Callable, const: bool
+        self, route_type: str, endpoint: str, handler: Callable, is_const: bool
     ) -> Union[Callable, CoroutineType]:
         @wraps(handler)
         async def async_inner_handler(*args):
@@ -56,11 +56,11 @@ class Router(BaseRouter):
         number_of_params = len(signature(handler).parameters)
         if iscoroutinefunction(handler):
             function = FunctionInfo(async_inner_handler, True, number_of_params)
-            self.routes.append((route_type, endpoint, function, const))
+            self.routes.append((route_type, endpoint, function, is_const))
             return async_inner_handler
         else:
             function = FunctionInfo(inner_handler, False, number_of_params)
-            self.routes.append((route_type, endpoint, function, const))
+            self.routes.append((route_type, endpoint, function, is_const))
             return inner_handler
 
     def get_routes(self) -> List[Route]:

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -4,6 +4,7 @@ from asyncio import iscoroutinefunction
 from inspect import signature
 from typing import Callable, Dict, List, Tuple, Union
 from types import CoroutineType
+from robyn.robyn import FunctionInfo
 
 from robyn.ws import WS
 
@@ -54,22 +55,12 @@ class Router(BaseRouter):
 
         number_of_params = len(signature(handler).parameters)
         if iscoroutinefunction(handler):
-            self.routes.append(
-                (
-                    route_type,
-                    endpoint,
-                    async_inner_handler,
-                    True,
-                    number_of_params,
-                    const,
-                )
-            )
-
+            function = FunctionInfo(async_inner_handler, True, number_of_params)
+            self.routes.append((route_type, endpoint, function, const))
             return async_inner_handler
         else:
-            self.routes.append(
-                (route_type, endpoint, inner_handler, False, number_of_params, const)
-            )
+            function = FunctionInfo(inner_handler, False, number_of_params)
+            self.routes.append((route_type, endpoint, function, const))
             return inner_handler
 
     def get_routes(self) -> List[Route]:
@@ -83,15 +74,8 @@ class MiddlewareRouter(BaseRouter):
 
     def add_route(self, route_type: str, endpoint: str, handler: Callable) -> Callable:
         number_of_params = len(signature(handler).parameters)
-        self.routes.append(
-            (
-                route_type,
-                endpoint,
-                handler,
-                iscoroutinefunction(handler),
-                number_of_params,
-            )
-        )
+        function = FunctionInfo(handler, iscoroutinefunction(handler), number_of_params)
+        self.routes.append((route_type, endpoint, function))
         return handler
 
     # These inner function is basically a wrapper arround the closure(decorator)

--- a/robyn/ws.py
+++ b/robyn/ws.py
@@ -4,6 +4,8 @@ import asyncio
 from inspect import signature
 from typing import TYPE_CHECKING, Callable
 
+from robyn.robyn import FunctionInfo
+
 if TYPE_CHECKING:
     from robyn import Robyn
 
@@ -21,10 +23,8 @@ class WS:
             if type not in ["connect", "close", "message"]:
                 raise Exception(f"Socket method {type} does not exist")
             else:
-                self.methods[type] = (
-                    handler,
-                    self._is_async(handler),
-                    self._num_params(handler),
+                self.methods[type] = FunctionInfo(
+                    handler, self._is_async(handler), self._num_params(handler)
                 )
                 self.robyn_object.add_web_socket(self.endpoint, self)
 

--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -1,299 +1,108 @@
 /// This is the module that has all the executor functions
 /// i.e. the functions that have the responsibility of parsing and executing functions.
 use crate::io_helpers::read_file;
+use crate::types::Request;
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use actix_web::{http::Method, web, HttpRequest};
-use anyhow::{bail, Result};
+use anyhow::{Context, Result};
 use log::debug;
 use pyo3_asyncio::TaskLocals;
 // pyO3 module
-use crate::types::PyFunction;
-use futures_util::stream::StreamExt;
+use crate::types::FunctionInfo;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
 
-/// @TODO make configurable
-const MAX_SIZE: usize = 10_000;
+fn get_function_output<'a>(
+    function: &'a FunctionInfo,
+    py: Python<'a>,
+    request: &Request,
+) -> Result<&'a PyAny, PyErr> {
+    let handler = function.handler.as_ref(py);
+    let request_hashmap = request.to_hashmap(py).unwrap();
+
+    // this makes the request object accessible across every route
+    match function.number_of_params {
+        0 => handler.call0(),
+        1 => handler.call1((request_hashmap,)),
+        // this is done to accommodate any future params
+        2_u8..=u8::MAX => handler.call1((request_hashmap,)),
+    }
+}
 
 pub async fn execute_middleware_function<'a>(
-    function: PyFunction,
-    payload: &mut web::Payload,
-    headers: &HashMap<String, String>,
-    req: &HttpRequest,
-    route_params: &HashMap<String, String>,
-    queries: &HashMap<String, String>,
-    number_of_params: u8,
+    request: &Request,
+    function: FunctionInfo,
 ) -> Result<HashMap<String, HashMap<String, String>>> {
     // TODO:
     // add body in middlewares too
 
-    let mut data: Vec<u8> = Vec::new();
-
-    if req.method() == Method::POST
-        || req.method() == Method::PUT
-        || req.method() == Method::PATCH
-        || req.method() == Method::DELETE
-    {
-        let mut body = web::BytesMut::new();
-        while let Some(chunk) = payload.next().await {
-            let chunk = chunk?;
-            // limit max size of in-memory payload
-            if (body.len() + chunk.len()) > MAX_SIZE {
-                bail!("Body content Overflow");
-            }
-            body.extend_from_slice(&chunk);
-        }
-
-        data = body.to_vec()
-    }
-
-    // request object accessible while creating routes
-    let mut request = HashMap::new();
-
-    match function {
-        PyFunction::CoRoutine(handler) => {
-            let output = Python::with_gil(|py| {
-                let handler = handler.as_ref(py);
-                request.insert("params", route_params.to_object(py));
-                request.insert("queries", queries.to_object(py));
-                // is this a bottleneck again?
-                request.insert("headers", headers.to_object(py));
-                // request.insert("body", data.into_py(py));
-
-                // this makes the request object to be accessible across every route
-                let coro: PyResult<&PyAny> = match number_of_params {
-                    0 => handler.call0(),
-                    1 => handler.call1((request,)),
-                    // this is done to accomodate any future params
-                    2_u8..=u8::MAX => handler.call1((request,)),
-                };
-                pyo3_asyncio::tokio::into_future(coro?)
-            })?;
-
-            let output = output.await?;
-
-            let res =
-                Python::with_gil(|py| -> PyResult<HashMap<String, HashMap<String, String>>> {
-                    let output: Vec<HashMap<String, HashMap<String, String>>> =
-                        output.extract(py)?;
-                    let responses = output[0].clone();
-                    Ok(responses)
-                })?;
-
-            Ok(res)
-        }
-
-        PyFunction::SyncFunction(handler) => {
-            // do we even need this?
-            // How else can we return a future from this?
-            // let's wrap the output in a future?
-            let output: Result<HashMap<String, HashMap<String, String>>> = Python::with_gil(|py| {
-                let handler = handler.as_ref(py);
-                request.insert("params", route_params.to_object(py));
-                request.insert("queries", queries.to_object(py));
-                // is this a bottleneck again?
-                request.insert("headers", headers.to_object(py));
-                request.insert("body", data.into_py(py));
-
-                let output: PyResult<&PyAny> = match number_of_params {
-                    0 => handler.call0(),
-                    1 => handler.call1((request,)),
-                    // this is done to accomodate any future params
-                    2_u8..=u8::MAX => handler.call1((request,)),
-                };
-
-                let output: Vec<HashMap<String, HashMap<String, String>>> = output?.extract()?;
-
-                Ok(output[0].clone())
-            });
-
-            Ok(output?)
-        }
-    }
-}
-
-pub async fn execute_function(
-    function: Py<PyAny>,
-    number_of_params: u8,
-    is_async: bool,
-) -> Result<HashMap<String, String>> {
-    let request: HashMap<String, String> = HashMap::new();
-
-    if is_async {
+    if function.is_async {
         let output = Python::with_gil(|py| {
-            let handler = function.as_ref(py);
-            let coro: PyResult<&PyAny> = match number_of_params {
-                0 => handler.call0(),
-                1 => handler.call1((request,)),
-                // this is done to accomodate any future params
-                2_u8..=u8::MAX => handler.call1((request,)),
-            };
-            pyo3_asyncio::tokio::into_future(coro?)
-        })?;
+            let function_output = get_function_output(&function, py, request);
+            pyo3_asyncio::tokio::into_future(function_output?)
+        })?
+        .await?;
 
-        let output = output.await?;
-        let res = Python::with_gil(|py| -> PyResult<HashMap<String, String>> {
-            debug!("This is the result of the code {:?}", output);
-
-            let mut res: HashMap<String, String> =
-                output.into_ref(py).downcast::<PyDict>()?.extract()?;
-
-            let response_type = res.get("type").unwrap();
-
-            if response_type == "static_file" {
-                let file_path = res.get("file_path").unwrap();
-                let contents = read_file(file_path).unwrap();
-                res.insert("body".to_owned(), contents);
-            }
-            Ok(res)
-        })?;
-
-        Ok(res)
-    } else {
-        tokio::task::spawn_blocking(move || {
-            Python::with_gil(|py| {
-                let handler = function.as_ref(py);
-                let output: PyResult<&PyAny> = match number_of_params {
-                    0 => handler.call0(),
-                    1 => handler.call1((request,)),
-                    // this is done to accomodate any future params
-                    2_u8..=u8::MAX => handler.call1((request,)),
-                };
-                let output: HashMap<String, String> = output?.extract()?;
-                // also convert to object here
-                // also check why don't sync functions have file handling enabled
-                Ok(output)
-            })
+        Python::with_gil(|py| -> PyResult<HashMap<String, HashMap<String, String>>> {
+            let output: Vec<HashMap<String, HashMap<String, String>>> = output.extract(py)?;
+            let responses = output[0].clone();
+            Ok(responses)
         })
-        .await?
+        .context("Failed to execute handler function")
+    } else {
+        Python::with_gil(|py| get_function_output(&function, py, request)?.extract())
+            .context("Failed to execute handler function")
     }
 }
 
 // Change this!
 #[inline]
 pub async fn execute_http_function(
-    function: PyFunction,
-    payload: &mut web::Payload,
-    headers: &HashMap<String, String>,
-    req: &HttpRequest,
-    route_params: &HashMap<String, String>,
-    queries: &HashMap<String, String>,
-    number_of_params: u8,
+    request: &Request,
+    function: FunctionInfo,
     // need to change this to return a response struct
     // create a custom struct for this
 ) -> Result<HashMap<String, String>> {
-    let mut data: Vec<u8> = Vec::new();
+    if function.is_async {
+        let output = Python::with_gil(|py| {
+            let function_output = get_function_output(&function, py, request);
+            pyo3_asyncio::tokio::into_future(function_output?)
+        })?
+        .await?;
+        let mut res: HashMap<String, String> =
+            Python::with_gil(|py| -> PyResult<HashMap<String, String>> { output.extract(py) })?;
 
-    if req.method() == Method::POST
-        || req.method() == Method::PUT
-        || req.method() == Method::PATCH
-        || req.method() == Method::DELETE
-    {
-        let mut body = web::BytesMut::new();
-        while let Some(chunk) = payload.next().await {
-            let chunk = chunk?;
-            // limit max size of in-memory payload
-            if (body.len() + chunk.len()) > MAX_SIZE {
-                bail!("Body content Overflow");
-            }
-            body.extend_from_slice(&chunk);
+        debug!("This is the result of the code {:?}", output);
+        if res.get("type").unwrap() == "static_file" {
+            let file_path = res.get("file_path").unwrap();
+            let contents = read_file(file_path).unwrap();
+            res.insert("body".to_owned(), contents);
         }
-
-        data = body.to_vec()
-    }
-
-    // request object accessible while creating routes
-    let mut request = HashMap::new();
-
-    match function {
-        PyFunction::CoRoutine(handler) => {
-            let output = Python::with_gil(|py| {
-                let handler = handler.as_ref(py);
-                request.insert("params", route_params.to_object(py));
-                request.insert("queries", queries.to_object(py));
-                request.insert("headers", headers.to_object(py));
-                let data = data.into_py(py);
-                request.insert("body", data);
-
-                // this makes the request object to be accessible across every route
-                let coro: PyResult<&PyAny> = match number_of_params {
-                    0 => handler.call0(),
-                    1 => handler.call1((request,)),
-                    // this is done to accomodate any future params
-                    2_u8..=u8::MAX => handler.call1((request,)),
-                };
-                pyo3_asyncio::tokio::into_future(coro?)
-            })?;
-
-            let output = output.await?;
-            let res = Python::with_gil(|py| -> PyResult<HashMap<String, String>> {
-                debug!("This is the result of the code {:?}", output);
-
-                let mut res: HashMap<String, String> =
-                    output.into_ref(py).downcast::<PyDict>()?.extract()?;
-
-                let response_type = res.get("type").unwrap();
-
-                if response_type == "static_file" {
-                    let file_path = res.get("file_path").unwrap();
-                    let contents = read_file(file_path).unwrap();
-                    res.insert("body".to_owned(), contents);
-                }
-                Ok(res)
-            })?;
-
-            Ok(res)
-        }
-
-        PyFunction::SyncFunction(handler) => {
-            Python::with_gil(|py| {
-                let handler = handler.as_ref(py);
-                request.insert("params", route_params.to_object(py));
-                request.insert("headers", headers.to_object(py));
-                let data = data.into_py(py);
-                request.insert("body", data);
-
-                let output: PyResult<&PyAny> = match number_of_params {
-                    0 => handler.call0(),
-                    1 => handler.call1((request,)),
-                    // this is done to accomodate any future params
-                    2_u8..=u8::MAX => handler.call1((request,)),
-                };
-                let output: HashMap<String, String> = output?.extract()?;
-                // also convert to object here
-                // also check why don't sync functions have file handling enabled
-                Ok(output)
-            })
-        }
+        Ok(res)
+    } else {
+        Python::with_gil(|py| get_function_output(&function, py, request)?.extract())
+            .context("Failed to execute handler function")
     }
 }
 
 pub async fn execute_event_handler(
-    event_handler: Option<Arc<PyFunction>>,
+    event_handler: Option<Arc<FunctionInfo>>,
     task_locals: &TaskLocals,
 ) -> Result<()> {
-    if let Some(handler) = event_handler {
-        match &(*handler) {
-            PyFunction::SyncFunction(function) => {
-                debug!("Startup event handler");
-                Python::with_gil(|py| -> Result<()> {
-                    function.call0(py)?;
-                    Ok(())
-                })?;
-            }
-            PyFunction::CoRoutine(function) => {
-                let future = Python::with_gil(|py| {
-                    debug!("Startup event handler async");
-
-                    let coroutine = function.as_ref(py).call0().unwrap();
-
-                    pyo3_asyncio::into_future_with_locals(task_locals, coroutine).unwrap()
-                });
-                future.await?;
-            }
+    if let Some(function) = event_handler {
+        if function.is_async {
+            debug!("Startup event handler async");
+            Python::with_gil(|py| {
+                pyo3_asyncio::into_future_with_locals(
+                    task_locals,
+                    function.handler.as_ref(py).call0()?,
+                )
+            })?
+            .await?;
+        } else {
+            debug!("Startup event handler");
+            Python::with_gil(|py| function.handler.call0(py))?;
         }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,14 @@ use shared_socket::SocketHeld;
 
 // pyO3 module
 use pyo3::prelude::*;
+use types::FunctionInfo;
 
 #[pymodule]
 pub fn robyn(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // the pymodule class to make the rustPyFunctions available
     m.add_class::<Server>()?;
     m.add_class::<SocketHeld>()?;
+    m.add_class::<FunctionInfo>()?;
     pyo3::prepare_freethreaded_python();
     Ok(())
 }

--- a/src/routers/const_router.rs
+++ b/src/routers/const_router.rs
@@ -2,12 +2,12 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::RwLock;
-// pyo3 modules
-use crate::executors::execute_function;
+
+use crate::executors::execute_http_function;
+use crate::types::{FunctionInfo, Request};
 use anyhow::Context;
 use log::debug;
 use matchit::Router as MatchItRouter;
-use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
 use actix_web::http::Method;
@@ -29,9 +29,7 @@ impl Router<String, Method> for ConstRouter {
         &self,
         route_type: &str, // we can just have route type as WS
         route: &str,
-        function: Py<PyAny>,
-        is_async: bool,
-        number_of_params: u8,
+        function: FunctionInfo,
         event_loop: Option<&PyAny>,
     ) -> Result<(), Error> {
         let table = self
@@ -44,7 +42,7 @@ impl Router<String, Method> for ConstRouter {
             event_loop.context("Event loop must be provided to add a route to the const router")?;
 
         pyo3_asyncio::tokio::run_until_complete(event_loop, async move {
-            let output = execute_function(function, number_of_params, is_async)
+            let output = execute_http_function(&Request::default(), function)
                 .await
                 .unwrap();
             debug!("This is the result of the output {:?}", output);

--- a/src/routers/mod.rs
+++ b/src/routers/mod.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use pyo3::{Py, PyAny};
+use pyo3::PyAny;
+
+use crate::types::FunctionInfo;
 
 pub mod const_router;
 pub mod http_router;
@@ -14,9 +16,7 @@ pub trait Router<T, U> {
         &self,
         route_type: &str,
         route: &str,
-        handler: Py<PyAny>,
-        is_async: bool,
-        number_of_params: u8,
+        function: FunctionInfo,
         event_loop: Option<&PyAny>,
     ) -> Result<()>;
 

--- a/src/routers/web_socket_router.rs
+++ b/src/routers/web_socket_router.rs
@@ -1,14 +1,12 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 // pyo3 modules
-use crate::types::PyFunction;
+use crate::types::FunctionInfo;
 use log::debug;
-use pyo3::prelude::*;
-use pyo3::types::PyAny;
 
 /// Contains the thread safe hashmaps of different routes
 
-type WebSocketRoutes = RwLock<HashMap<String, HashMap<String, (PyFunction, u8)>>>;
+type WebSocketRoutes = RwLock<HashMap<String, HashMap<String, FunctionInfo>>>;
 
 pub struct WebSocketRouter {
     web_socket_routes: WebSocketRoutes,
@@ -31,52 +29,25 @@ impl WebSocketRouter {
     pub fn add_websocket_route(
         &self,
         route: &str,
-        connect_route: (Py<PyAny>, bool, u8),
-        close_route: (Py<PyAny>, bool, u8),
-        message_route: (Py<PyAny>, bool, u8),
+        connect_route: FunctionInfo,
+        close_route: FunctionInfo,
+        message_route: FunctionInfo,
     ) {
         let table = self.get_web_socket_map();
-        let (connect_route_function, connect_route_is_async, connect_route_params) = connect_route;
-        let (close_route_function, close_route_is_async, close_route_params) = close_route;
-        let (message_route_function, message_route_is_async, message_route_params) = message_route;
 
-        let insert_in_router =
-            |handler: Py<PyAny>, is_async: bool, number_of_params: u8, socket_type: &str| {
-                let function = if is_async {
-                    PyFunction::CoRoutine(handler)
-                } else {
-                    PyFunction::SyncFunction(handler)
-                };
+        let insert_in_router = |function: FunctionInfo, socket_type: &str| {
+            debug!("socket type is {:?} {:?}", table, route);
 
-                debug!("socket type is {:?} {:?}", table, route);
+            table
+                .write()
+                .unwrap()
+                .entry(route.to_string())
+                .or_default()
+                .insert(socket_type.to_string(), function)
+        };
 
-                table
-                    .write()
-                    .unwrap()
-                    .entry(route.to_string())
-                    .or_default()
-                    .insert(socket_type.to_string(), (function, number_of_params))
-            };
-
-        insert_in_router(
-            connect_route_function,
-            connect_route_is_async,
-            connect_route_params,
-            "connect",
-        );
-
-        insert_in_router(
-            close_route_function,
-            close_route_is_async,
-            close_route_params,
-            "close",
-        );
-
-        insert_in_router(
-            message_route_function,
-            message_route_is_async,
-            message_route_params,
-            "message",
-        );
+        insert_in_router(connect_route, "connect");
+        insert_in_router(close_route, "close");
+        insert_in_router(message_route, "message");
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -257,14 +257,14 @@ impl Server {
         route_type: &str,
         route: &str,
         function: FunctionInfo,
-        const_route: bool,
+        is_const: bool,
     ) {
         debug!("Route added for {} {} ", route_type, route);
         // let event_loop = pyo3_asyncio::tokio::get_current_loop(py).unwrap();
         let asyncio = py.import("asyncio").unwrap();
         let event_loop = asyncio.call_method0("get_event_loop").unwrap();
 
-        if const_route {
+        if is_const {
             self.const_router
                 .add_route(route_type, route, function, Some(event_loop))
                 .unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,10 +1,49 @@
+use std::collections::HashMap;
+
+use actix_web::http::Method;
+use actix_web::web::Bytes;
+use anyhow::Result;
 use dashmap::DashMap;
 use pyo3::prelude::*;
 
+#[pyclass]
 #[derive(Debug, Clone)]
-pub enum PyFunction {
-    CoRoutine(Py<PyAny>),
-    SyncFunction(Py<PyAny>),
+pub struct FunctionInfo {
+    pub handler: Py<PyAny>,
+    pub is_async: bool,
+    pub number_of_params: u8,
+}
+
+#[pymethods]
+impl FunctionInfo {
+    #[new]
+    pub fn new(handler: Py<PyAny>, is_async: bool, number_of_params: u8) -> Self {
+        Self {
+            handler,
+            is_async,
+            number_of_params,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Request {
+    pub queries: HashMap<String, String>,
+    pub headers: HashMap<String, String>,
+    pub method: Method,
+    pub params: HashMap<String, String>,
+    pub body: Bytes,
+}
+
+impl Request {
+    pub fn to_hashmap(&self, py: Python<'_>) -> Result<HashMap<&str, Py<PyAny>>> {
+        let mut result = HashMap::new();
+        result.insert("params", self.params.to_object(py));
+        result.insert("queries", self.queries.to_object(py));
+        result.insert("headers", self.headers.to_object(py));
+        result.insert("body", self.body.to_object(py));
+        Ok(result)
+    }
 }
 
 pub type Headers = DashMap<String, String>;


### PR DESCRIPTION
**Description**

This PR is a big refactor of Robyn's core. It aims at simplifying the code by factorizing it and introducing new useful structs. Here is a description of what I've done to achieve this:
- Create a `Request` struct that wraps the parameters of a request (`queries`, `headers`, `method`, `params`, and `body`)
- Use the `Request` struct in request handlers and executors instead of using each parameters of a request separately
- Create a `FunctionInfo` struct to describe functions coming from Python. This struct is made available in the Python code too and wraps `handler`, `is_async` and `number_of_params`
- The `FunctionInfo` struct replace `handler`, `is_async` and `number_of_params` in every function call
- The `execute_function` function that was used by the const router has been removed as it was very similar to `execute_http_function`. Const router now uses `execute_http_function` (not sure about this one, let me know if I should restore `execute_function` which used `tokio::task::spawn_blocking` while `execute_http_function` doesn't)

This a big PR and it affects a lot of modules. It may need some time to be fully reviewed, do not hesitate to ask me questions about it and ask me to restore some parts if I made mistakes :)