### PR TITLE
feat: return Response from routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dist/
 
 # DS_Store
 *.DS_Store
-.vscode/settings.json
+.vscode
 
 # python venv
 venv

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -15,6 +15,12 @@ class FunctionInfo:
     is_async: bool
     number_of_params: int
 
+@dataclass
+class Response:
+    status_code: int
+    headers: dict[str, str]
+    body: str
+
 class Server:
     def __init__(self) -> None:
         pass

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -4,7 +4,7 @@ from asyncio import iscoroutinefunction
 from inspect import signature
 from typing import Callable, Dict, List, Tuple, Union
 from types import CoroutineType
-from robyn.robyn import FunctionInfo
+from robyn.robyn import FunctionInfo, Response
 from robyn.responses import jsonify
 
 from robyn.ws import WS
@@ -29,25 +29,20 @@ class Router(BaseRouter):
         response = {}
         if type(res) == dict:
             status_code = res.get("status_code", 200)
-            headers = res.get("headers", {})
+            headers = res.get("headers", {"Content-Type": "text/plain"})
             body = res.get("body", "")
 
             if type(status_code) != int:
                 status_code = int(status_code)  # status_code can potentially be string
 
-            response = {
-                "status_code": status_code,
-                "body": body,
-                "headers": headers,
-                **res,
-            }
+            response = Response(status_code=status_code, headers=headers, body=body)
+            file_path = res.get("file_path")
+            if file_path is not None:
+                response.set_file_path(file_path)
         else:
-            response = {
-                "status_code": 200,
-                "body": res,
-                "type": "text",
-                "headers": {"Content-Type": "text/plain"},
-            }
+            response = Response(
+                status_code=200, headers={"Content-Type": "text/plain"}, body=res
+            )
 
         return response
 

--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -1,6 +1,5 @@
 /// This is the module that has all the executor functions
 /// i.e. the functions that have the responsibility of parsing and executing functions.
-use crate::io_helpers::read_file;
 use crate::types::{FunctionInfo, Request, Response};
 
 use std::collections::HashMap;
@@ -8,7 +7,6 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use log::debug;
-use pyo3::types::PyDict;
 use pyo3_asyncio::TaskLocals;
 // pyO3 module
 use pyo3::prelude::*;
@@ -65,52 +63,14 @@ pub async fn execute_http_function(request: &Request, function: FunctionInfo) ->
         })?
         .await?;
 
-        // convert the output to a PyDict
-        let res = Python::with_gil(|py| -> Result<Response> {
-            let output: Py<PyDict> = output.extract(py)?;
-
-            let output_type = output.as_ref(py).get_item("type");
-            let output = output.as_ref(py);
-
-            if let Some(output_type) = output_type {
-                let output_type: String = output_type.extract()?;
-
-                if output_type == "static_file" {
-                    let file_path: String = output.get_item("file_path").unwrap().extract()?;
-                    let contents = read_file(&file_path).unwrap();
-                    output.set_item("body", contents)?;
-                }
-            };
-
-            let status_code = output.get_item("status_code").unwrap();
-            let status_code: u16 = status_code.extract().unwrap();
-
-            let body = output.get_item("body").unwrap();
-            let body: String = body.extract().unwrap();
-
-            let headers = output.get_item("headers");
-
-            let headers = if let Some(headers) = headers {
-                let some_headers: HashMap<String, String> =
-                    headers.extract::<HashMap<String, String>>().unwrap();
-                some_headers
-            } else {
-                HashMap::new()
-            };
-
-            Ok(Response::new(status_code, headers, body))
-        })?;
-
-        debug!("This is the result of the code {:?}", output);
-        Ok(res)
-    } else {
-        let res = Python::with_gil(|py| {
-            let py_obj = get_function_output(&function, py, request).unwrap();
-            Response::from_obj(py, py_obj)
+        Python::with_gil(|py| -> Result<Response> {
+            output.extract(py).context("Failed to get route response")
         })
-        .unwrap();
-
-        Ok(res)
+    } else {
+        Python::with_gil(|py| -> Result<Response> {
+            let output = get_function_output(&function, py, request).unwrap();
+            output.extract().context("Failed to get route response")
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use shared_socket::SocketHeld;
 
 // pyO3 module
 use pyo3::prelude::*;
-use types::FunctionInfo;
+use types::{FunctionInfo, Response};
 
 #[pymodule]
 pub fn robyn(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
@@ -19,6 +19,7 @@ pub fn robyn(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<Server>()?;
     m.add_class::<SocketHeld>()?;
     m.add_class::<FunctionInfo>()?;
+    m.add_class::<Response>()?;
     pyo3::prepare_freethreaded_python();
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -365,13 +365,15 @@ async fn index(
 
     let response = if let Some(r) = const_router.get_route(req.method(), req.uri().path()) {
         apply_hashmap_headers(&mut response_builder, &r.headers);
-        response_builder.status(r.status_code).body(r.body)
+        response_builder
+            .status(StatusCode::from_u16(r.status_code).unwrap())
+            .body(r.body)
     } else if let Some((function, route_params)) = router.get_route(req.method(), req.uri().path())
     {
         request.params = route_params;
         match execute_http_function(&request, function).await {
             Ok(r) => {
-                response_builder.status(r.status_code);
+                response_builder.status(StatusCode::from_u16(r.status_code).unwrap());
                 apply_hashmap_headers(&mut response_builder, &r.headers);
                 if !r.body.is_empty() {
                     response_builder.body(r.body)

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-use actix_http::StatusCode;
 use actix_web::web::Bytes;
 use actix_web::{http::Method, HttpRequest};
 use anyhow::Result;
 use dashmap::DashMap;
-use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::{exceptions, prelude::*};
+
+use crate::io_helpers::read_file;
 
 #[pyclass]
 #[derive(Debug, Clone)]
@@ -75,43 +75,34 @@ impl Request {
 #[derive(Debug, Clone)]
 #[pyclass]
 pub struct Response {
-    pub status_code: StatusCode,
+    pub status_code: u16,
+    pub response_type: String,
     pub headers: HashMap<String, String>,
     pub body: String,
-}
-
-impl Response {
-    pub fn new(status_code: u16, headers: HashMap<String, String>, body: String) -> Self {
-        Self {
-            status_code: StatusCode::from_u16(status_code).unwrap(),
-            headers,
-            body,
-        }
-    }
+    pub file_path: Option<String>,
 }
 
 #[pymethods]
 impl Response {
     #[new]
-    pub fn from_obj(py: Python<'_>, input: &PyAny) -> PyResult<Self> {
-        let input: Py<PyDict> = input.extract().unwrap();
-        let input = input.as_ref(py);
+    pub fn new(status_code: u16, headers: HashMap<String, String>, body: String) -> Self {
+        Self {
+            status_code,
+            response_type: "text".to_string(),
+            headers,
+            body,
+            file_path: None,
+        }
+    }
 
-        let status_code = input
-            .get_item("status_code")
-            .unwrap()
-            .extract::<u16>()
-            .unwrap();
-
-        let headers = input
-            .get_item("headers")
-            .unwrap()
-            .extract::<HashMap<String, String>>()
-            .unwrap();
-
-        let body = input.get_item("body").unwrap().to_owned();
-
-        Ok(Self::new(status_code, headers, body.to_string()))
+    pub fn set_file_path(&mut self, file_path: &str) -> PyResult<()> {
+        self.response_type = "static_file".to_string();
+        self.file_path = Some(file_path.to_string());
+        self.body = match read_file(file_path) {
+            Ok(b) => b,
+            Err(e) => return Err(exceptions::PyIOError::new_err::<String>(e.to_string())),
+        };
+        Ok(())
     }
 }
 


### PR DESCRIPTION
**Description**

This PR makes `Response` a `pyclass`.
There is no more need to convert a `Pydict` to a `Response` in the `execute_http_function` method, as the result will already be a `Response`.
Can you tell me what you think of it @sansyrox ? :slightly_smiling_face: 