### PR TITLE
fix: fix the static file serving

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -20,13 +20,28 @@ app.start(port=5000)
 ### Serving simple HTML Files
 ```python
 
-from robyn import Robyn, static_file
+from robyn import Robyn, serve_html
 
 app = Robyn(__file__)
 
 @app.get("/")
 async def h(request):
-    return static_file("./index.html")
+    return serve_html("./index.html")
+
+app.start(port=5000)
+
+```
+
+### Serving files to download
+```python
+
+from robyn import Robyn, serve_file
+
+app = Robyn(__file__)
+
+@app.get("/")
+async def h(request):
+    return serve_file("./index.html")
 
 app.start(port=5000)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -164,7 +164,7 @@ You can now serve websockets using Robyn.
 Firstly, you need to create a WebSocket Class and wrap it around your Robyn app.
 
 ```python
-from robyn import Robyn, static_file, jsonify, WS
+from robyn import Robyn, jsonify, WS
 
 
 app = Robyn(__file__)

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -26,7 +26,7 @@ Note - Railway looks for a `main.py` as an entrypoint instead of `app.py`. The b
 
 *main.py*
 ```python
-from robyn import Robyn, static_file
+from robyn import Robyn, serve_html
 
 
 app = Robyn(__file__)
@@ -39,7 +39,7 @@ async def h(request):
 
 @app.get("/")
 async def get_page(request):
-    return static_file("./index.html")
+    return serve_html("./index.html")
 
 if __name__=="__main__":
     app.start(url="0.0.0.0", port=PORT)    

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -1,4 +1,4 @@
-from robyn import Robyn, static_file, jsonify, WS, html
+from robyn import Robyn, serve_file, jsonify, WS, serve_html
 
 from robyn.templating import JinjaTemplate
 
@@ -120,7 +120,7 @@ async def test(request):
     current_file_path = pathlib.Path(__file__).parent.resolve()
     html_file = os.path.join(current_file_path, "index.html")
 
-    return html(html_file)
+    return serve_html(html_file)
 
 
 @app.get("/template_render")
@@ -230,6 +230,20 @@ async def redirect(request):
 @app.get("/redirect_route")
 async def redirect_route(request):
     return "This is the redirected route"
+
+
+@app.get("/file_download_sync")
+def file_download_sync():
+    current_file_path = pathlib.Path(__file__).parent.resolve()
+    file_path = os.path.join(current_file_path, "downloads", "test.txt")
+    return serve_file(file_path)
+
+
+@app.get("/file_download_async")
+def file_download_async():
+    current_file_path = pathlib.Path(__file__).parent.resolve()
+    file_path = os.path.join(current_file_path, "downloads", "test.txt")
+    return serve_file(file_path)
 
 
 if __name__ == "__main__":

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -1,4 +1,4 @@
-from robyn import Robyn, static_file, jsonify, WS
+from robyn import Robyn, static_file, jsonify, WS, html
 
 from robyn.templating import JinjaTemplate
 
@@ -120,7 +120,7 @@ async def test(request):
     current_file_path = pathlib.Path(__file__).parent.resolve()
     html_file = os.path.join(current_file_path, "index.html")
 
-    return static_file(html_file)
+    return html(html_file)
 
 
 @app.get("/template_render")

--- a/integration_tests/downloads/test.txt
+++ b/integration_tests/downloads/test.txt
@@ -1,0 +1,1 @@
+This is a test file for the downloading purpose

--- a/integration_tests/test_file_download.py
+++ b/integration_tests/test_file_download.py
@@ -1,0 +1,17 @@
+import requests
+
+BASE_URL = "http://127.0.0.1:5000"
+
+
+def test_file_download_sync(session):
+    r = requests.get(f"{BASE_URL}/file_download_sync")
+    assert r.status_code == 200
+    assert r.headers["Content-Disposition"] == "attachment"
+    assert r.text == "This is a test file for the downloading purpose\n"
+
+
+def test_file_download_async(session):
+    r = requests.get(f"{BASE_URL}/file_download_async")
+    assert r.status_code == 200
+    assert r.headers["Content-Disposition"] == "attachment"
+    assert r.text == "This is a test file for the downloading purpose\n"

--- a/integration_tests/test_get_requests.py
+++ b/integration_tests/test_get_requests.py
@@ -58,3 +58,4 @@ def test_const_request_headers(session):
     assert r.status_code == 200
     assert "Header" in r.headers
     assert r.headers["Header"] == "header_value"
+

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -14,7 +14,7 @@ from robyn.dev_event_handler import EventHandler
 from robyn.events import Events
 from robyn.log_colors import Colors
 from robyn.processpool import spawn_process
-from robyn.responses import jsonify, static_file
+from robyn.responses import jsonify, serve_file, serve_html
 from robyn.robyn import FunctionInfo, SocketHeld
 from robyn.router import MiddlewareRouter, Router, WebSocketRouter
 from robyn.ws import WS
@@ -312,3 +312,6 @@ class Robyn:
 
         log_level = self.log_level if self.log_level else log_level
         logging.basicConfig(level=log_level)
+
+
+__all__ = ["Robyn", "jsonify", "serve_file", "serve_html"]

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -2,19 +2,29 @@ import json
 from typing import Any, Dict
 
 
-def static_file(file_path: str) -> Dict[str, Any]:
+def serve_html(file_path: str) -> Dict[str, Any]:
     """
-    This function will help in serving a static_file
+    This function will help in serving a single html file
 
     :param file_path str: file path to serve as a response
     """
 
     return {
-        "type": "static_file",
         "file_path": file_path,
-        # this is a hack for now
-        "body": "",
-        "status_code": 200,
+        "headers": {"Content-Type": "text/html"},
+    }
+
+
+def serve_file(file_path: str) -> Dict[str, Any]:
+    """
+    This function will help in serving a file
+
+    :param file_path str: file path to serve as a response
+    """
+
+    return {
+        "file_path": file_path,
+        "headers": {"Content-Disposition": "attachment"},
     }
 
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,6 +88,7 @@ impl Response {
     pub fn new(status_code: u16, headers: HashMap<String, String>, body: String) -> Self {
         Self {
             status_code,
+            // we should be handling based on headers but works for now
             response_type: "text".to_string(),
             headers,
             body,
@@ -96,6 +97,7 @@ impl Response {
     }
 
     pub fn set_file_path(&mut self, file_path: &str) -> PyResult<()> {
+        // we should be handling based on headers but works for now
         self.response_type = "static_file".to_string();
         self.file_path = Some(file_path.to_string());
         self.body = match read_file(file_path) {


### PR DESCRIPTION
This fixes the issues with static file serving of html files and also allows you to serve downloadable static files

BREAKING CHANGE:

**Description**

This PR fixes #343 #344 

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->