### PR TITLE
fix: better handling of route return type

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -97,8 +97,44 @@ from robyn import jsonify
 
 @app.post("/jsonify")
 async def json(request):
-    print(request)
     return jsonify({"hello": "world"})
+```
+
+## Format of the Response
+Robyn supports several kind of Response for your routes
+
+#### Dictionary
+Robyn accepts dictionaries to build a response for the route:
+
+```python
+@app.post("/dictionary")
+async def dictionary(request):
+    return {
+        "status_code": 200,
+        "body": "This is a regular response",
+        "type": "text",
+        "headers": {"Header": "header_value"},
+    }
+```
+
+#### Response object
+Robyn provides a `Response` object to help you build a valid response.
+
+```python
+from robyn.robyn import Response
+
+@app.get("/response")
+async def response(request):
+    return Response(status_code=200, headers={}, body="OK")
+```
+
+#### Other types
+Whenever you want to use an other type for your routes, the `str` method will be called on it and it will be stored in the body of the response. Here is an example that returns a string:
+
+```python
+@app.get("/")
+async def hello(request):
+    return "Hello World"
 ```
 
 ## Global Headers

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -1,4 +1,5 @@
 from robyn import Robyn, serve_file, jsonify, WS, serve_html
+from robyn.robyn import Response
 
 from robyn.templating import JinjaTemplate
 
@@ -230,6 +231,36 @@ async def redirect(request):
 @app.get("/redirect_route")
 async def redirect_route(request):
     return "This is the redirected route"
+
+
+@app.get("/types/response")
+def response_type(request):
+    return Response(status_code=200, headers={}, body="OK")
+
+
+@app.get("/types/str")
+def str_type(request):
+    return "OK"
+
+
+@app.get("/types/int")
+def int_type(request):
+    return 0
+
+
+@app.get("/async/types/response")
+async def async_response_type(request):
+    return Response(status_code=200, headers={}, body="OK")
+
+
+@app.get("/async/types/str")
+async def async_str_type(request):
+    return "OK"
+
+
+@app.get("/async/types/int")
+async def async_int_type(request):
+    return 0
 
 
 @app.get("/file_download_sync")

--- a/integration_tests/test_get_requests.py
+++ b/integration_tests/test_get_requests.py
@@ -59,3 +59,38 @@ def test_const_request_headers(session):
     assert "Header" in r.headers
     assert r.headers["Header"] == "header_value"
 
+
+def test_response_type(session):
+    r = requests.get(f"{BASE_URL}/types/response")
+    assert r.status_code == 200
+    assert r.text == "OK"
+
+
+def test_str_type(session):
+    r = requests.get(f"{BASE_URL}/types/str")
+    assert r.status_code == 200
+    assert r.text == "OK"
+
+
+def test_int_type(session):
+    r = requests.get(f"{BASE_URL}/types/int")
+    assert r.status_code == 200
+    assert r.text == "0"
+
+
+def test_async_response_type(session):
+    r = requests.get(f"{BASE_URL}/async/types/response")
+    assert r.status_code == 200
+    assert r.text == "OK"
+
+
+def test_async_str_type(session):
+    r = requests.get(f"{BASE_URL}/async/types/str")
+    assert r.status_code == 200
+    assert r.text == "OK"
+
+
+def test_async_int_type(session):
+    r = requests.get(f"{BASE_URL}/async/types/int")
+    assert r.status_code == 200
+    assert r.text == "0"

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -25,7 +25,6 @@ class Router(BaseRouter):
         self.routes = []
 
     def _format_response(self, res):
-        # handle file handlers
         response = {}
         if type(res) == dict:
             status_code = res.get("status_code", 200)
@@ -39,9 +38,11 @@ class Router(BaseRouter):
             file_path = res.get("file_path")
             if file_path is not None:
                 response.set_file_path(file_path)
+        elif type(res) == Response:
+            response = res
         else:
             response = Response(
-                status_code=200, headers={"Content-Type": "text/plain"}, body=res
+                status_code=200, headers={"Content-Type": "text/plain"}, body=str(res)
             )
 
         return response


### PR DESCRIPTION
**Description**

I figured there are issues when you try to return something other than a string or a dict in a route. With this PR, you can return anything and most notably directly a `Response`.
We may want to add it to the doc if it seems relevant to you @sansyrox ?