### PR TITLE
Replace the default port with 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ app = Robyn(__file__)
 async def h(request):
     return "Hello, world!"
 
-app.start(port=5000)
+app.start(port=8080)
+
 ```
 
 ## 💡 Features

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -70,7 +70,7 @@ python3 ./integration_tests/base_routes.py &
 sleep 1
 
 # oha will display benchmark results
-oha -n "$number" http://localhost:5000/sync
+oha -n "$number" http://localhost:8080/sync
 
 # Kill subprocesses after exiting the script (python + robyn server)
 # (see https://stackoverflow.com/questions/360201/how-do-i-kill-background-processes-jobs-when-my-shell-script-exits)

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,8 +40,7 @@ app = Robyn(__file__)
 async def h(request):
     return "Hello, world!"
 
-
-app.start(port=5000)
+app.start(port=8080)
 ```
 
 ## 💡 Features

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -18,6 +18,6 @@ e.g. structure
 Sample `robyn.env`
 
 ```
-ROBYN_PORT=5000
+ROBYN_PORT=8080
 ROBYN_URL=127.0.0.1
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -14,8 +14,7 @@ app = Robyn(__file__)
 async def h(request):
     return "Hello, world!"
 
-
-app.start(port=5000)
+app.start(port=8080)
 ```
 
 ### Serving simple HTML Files
@@ -30,8 +29,7 @@ app = Robyn(__file__)
 async def h(request):
     return serve_html("./index.html")
 
-
-app.start(port=5000)
+app.start(port=8080)
 ```
 
 ### Serving files to download
@@ -46,8 +44,8 @@ app = Robyn(__file__)
 async def h(request):
     return serve_file("./index.html")
 
+app.start(port=8080)
 
-app.start(port=5000)
 ```
 
 ### Interaction with a Database
@@ -83,8 +81,7 @@ async def h():
     )
     return user.json(indent=2)
 
-
-app.start(port=5000)
+app.start(port=8080)
 ```
 
 Using this Prisma Schema:

--- a/docs/features.md
+++ b/docs/features.md
@@ -167,7 +167,7 @@ async def request_headers():
 
 You can access query params from every HTTP method.
 
-For the url: `http://localhost:5000/query?a=b`
+For the url: `http://localhost:8080/query?a=b`
 
 You can use the following code snippet.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,8 +40,7 @@ app = Robyn(__file__)
 async def h(request):  # request is an optional parameter
     return "Hello, world!"
 
-
-app.start(port=5000, url="0.0.0.0")  # url is optional, defaults to 127.0.0.1
+app.start(port=8080, url="0.0.0.0") # url is optional, defaults to 127.0.0.1
 ```
 
 Let us try to decipher the usage line by line.

--- a/docs/landing_page/index.html
+++ b/docs/landing_page/index.html
@@ -82,7 +82,7 @@ app = Robyn(__file__)
 async def h(request):
     return "Hello, world!"
 
-app.start(port=5000)</code></pre>
+app.start(port=8080)</code></pre>
             </div>
           </div>
         </div>

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -285,4 +285,4 @@ if __name__ == "__main__":
         index_file="index.html",
     )
     app.startup_handler(startup_handler)
-    app.start(port=5000)
+    app.start(port=8080)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -70,7 +70,7 @@ def global_session():
 @pytest.fixture(scope="session")
 def dev_session():
     os.environ["ROBYN_URL"] = "127.0.0.1"
-    os.environ["ROBYN_PORT"] = "5001"
+    os.environ["ROBYN_PORT"] = "8081"
     current_file_path = pathlib.Path(__file__).parent.resolve()
     base_routes = os.path.join(current_file_path, "./base_routes.py")
     command = ["python3", base_routes, "--dev"]

--- a/integration_tests/test_base_url.py
+++ b/integration_tests/test_base_url.py
@@ -1,5 +1,4 @@
 import os
-
 import requests
 
 
@@ -24,7 +23,7 @@ def test_global_index_request(global_session):
 
 
 def test_dev_index_request(dev_session):
-    BASE_URL = "http://127.0.0.1:5001"
+    BASE_URL = "http://127.0.0.1:8081"
     res = requests.get(f"{BASE_URL}")
-    assert os.getenv("ROBYN_PORT") == "5001"
+    assert os.getenv("ROBYN_PORT") == "8081"
     assert res.status_code == 200

--- a/integration_tests/test_base_url.py
+++ b/integration_tests/test_base_url.py
@@ -4,20 +4,20 @@ import requests
 
 
 def test_default_url_index_request(default_session):
-    BASE_URL = "http://127.0.0.1:5000"
+    BASE_URL = "http://127.0.0.1:8080"
     res = requests.get(f"{BASE_URL}")
     assert res.status_code == 200
 
 
 def test_local_index_request(session):
-    BASE_URL = "http://127.0.0.1:5000"
+    BASE_URL = "http://127.0.0.1:8080"
     res = requests.get(f"{BASE_URL}")
     assert os.getenv("ROBYN_URL") == "127.0.0.1"
     assert res.status_code == 200
 
 
 def test_global_index_request(global_session):
-    BASE_URL = "http://0.0.0.0:5000"
+    BASE_URL = "http://0.0.0.0:8080"
     res = requests.get(f"{BASE_URL}")
     assert os.getenv("ROBYN_URL") == "0.0.0.0"
     assert res.status_code == 200

--- a/integration_tests/test_delete_requests.py
+++ b/integration_tests/test_delete_requests.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = "http://127.0.0.1:5000"
+BASE_URL = "http://127.0.0.1:8080"
 
 
 def test_delete(session):

--- a/integration_tests/test_env_populator.py
+++ b/integration_tests/test_env_populator.py
@@ -12,7 +12,7 @@ path = pathlib.Path(__file__).parent
 # create robyn.env before test and delete it after test
 @pytest.fixture
 def env_file():
-    CONTENT = """ROBYN_PORT=8080
+    CONTENT = """ROBYN_PORT=8081
     ROBYN_URL=127.0.0.1"""
     env_path = path / "robyn.env"
     env_path.write_text(CONTENT)

--- a/integration_tests/test_file_download.py
+++ b/integration_tests/test_file_download.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = "http://127.0.0.1:5000"
+BASE_URL = "http://127.0.0.1:8080"
 
 
 def test_file_download_sync(session):

--- a/integration_tests/test_get_requests.py
+++ b/integration_tests/test_get_requests.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = "http://127.0.0.1:5000"
+BASE_URL = "http://127.0.0.1:8080"
 
 
 def test_index_request(session):

--- a/integration_tests/test_patch_requests.py
+++ b/integration_tests/test_patch_requests.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = "http://127.0.0.1:5000"
+BASE_URL = "http://127.0.0.1:8080"
 
 
 def test_patch(session):

--- a/integration_tests/test_post_requests.py
+++ b/integration_tests/test_post_requests.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = "http://127.0.0.1:5000"
+BASE_URL = "http://127.0.0.1:8080"
 
 
 def test_post(session):

--- a/integration_tests/test_put_requests.py
+++ b/integration_tests/test_put_requests.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = "http://127.0.0.1:5000"
+BASE_URL = "http://127.0.0.1:8080"
 
 
 def test_put(session):

--- a/integration_tests/test_status_code.py
+++ b/integration_tests/test_status_code.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = "http://127.0.0.1:5000"
+BASE_URL = "http://127.0.0.1:8080"
 
 
 def test_404_status_code(session):

--- a/integration_tests/test_web_sockets.py
+++ b/integration_tests/test_web_sockets.py
@@ -1,6 +1,6 @@
 from websocket import create_connection
 
-BASE_URL = "ws://127.0.0.1:5000"
+BASE_URL = "ws://127.0.0.1:8080"
 
 
 def test_web_socket(session):

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -107,7 +107,7 @@ class Robyn:
     def shutdown_handler(self, handler: Callable) -> None:
         self._add_event_handler(Events.SHUTDOWN, handler)
 
-    def start(self, url: str = "127.0.0.1", port: int = 5000):
+    def start(self, url: str = "127.0.0.1", port: int = 8080):
         """
         Starts the server
 

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -1,12 +1,14 @@
 import asyncio
 import sys
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple, List
 
 from robyn.events import Events
 from robyn.robyn import FunctionInfo, Server, SocketHeld
 from robyn.router import MiddlewareRoute, Route
 from robyn.types import Directory, Header
 from robyn.ws import WS
+from robyn.types import Directory, Header
+
 
 
 def initialize_event_loop():

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -1,6 +1,6 @@
 import asyncio
 import sys
-from typing import Dict, Tuple, List
+from typing import Dict, List
 
 from robyn.events import Events
 from robyn.robyn import FunctionInfo, Server, SocketHeld

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -21,6 +21,10 @@ class Response:
     headers: dict[str, str]
     body: str
 
+    def set_file_path(file_path):
+        pass
+
+
 class Server:
     def __init__(self) -> None:
         pass

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -21,7 +21,7 @@ class Response:
     headers: dict[str, str]
     body: str
 
-    def set_file_path(file_path):
+    def set_file_path(self, file_path: str):
         pass
 
 

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -9,8 +9,8 @@ from robyn.responses import jsonify
 from robyn.robyn import FunctionInfo, Response
 from robyn.ws import WS
 
-Route = Tuple[str, str, Callable, bool]
-MiddlewareRoute = Tuple[str, str, Callable]
+Route = Tuple[str, str, FunctionInfo, bool]
+MiddlewareRoute = Tuple[str, str, FunctionInfo]
 
 
 class BaseRouter(ABC):

--- a/robyn/types.py
+++ b/robyn/types.py
@@ -25,3 +25,4 @@ class Header:
 
     def as_list(self):
         return [self.key, self.val]
+


### PR DESCRIPTION
OSX has some service running on port 5000 by default. It makes it annoying to work on Robyn to keep changing the default port number all the time.

**Description**

This changes the default PORT of Robyn.

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->