### PR TITLE
chore(ci): add python 3.11 to the build and test CI

### DIFF
--- a/.github/workflows/build-CI.yml
+++ b/.github/workflows/build-CI.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -51,7 +51,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         target: [x64, x86]
     steps:
       - uses: actions/checkout@v3
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         target: [x86_64, i686]
     steps:
       - uses: actions/checkout@v3
@@ -125,6 +125,7 @@ jobs:
             { version: "3.8", abi: "cp38-cp38" },
             { version: "3.9", abi: "cp39-cp39" },
             { version: "3.10", abi: "cp310-cp310" },
+            { version: "3.11", abi: "cp311-cp311" },
           ]
         target: [aarch64, armv7, s390x, ppc64le]
     steps:

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,9 @@ dependencies = [
   'watchdog == 2.1.3',
   'multiprocess == 0.70.12.2',
 # conditional
-  'uvloop == 0.16.0; sys_platform == "darwin"',
-  'uvloop == 0.16.0; platform_machine == "x86_64"',
-  'uvloop == 0.16.0; platform_machine == "i686"'
+  'uvloop == 0.17.0; sys_platform == "darwin"',
+  'uvloop == 0.17.0; platform_machine == "x86_64"',
+  'uvloop == 0.17.0; platform_machine == "i686"'
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/robyn/test-requirements.txt
+++ b/robyn/test-requirements.txt
@@ -2,7 +2,7 @@ pytest==6.2.5
 maturin==0.12.11
 watchdog
 requests==2.26.0
-uvloop==0.16.0
+uvloop==0.17.0
 multiprocess==0.70.12.2
 websockets==10.1
 jinja2==3.0.2


### PR DESCRIPTION
**Description**

This PR fixes #357

Adds python 3.11 to the CI.
This should also allow to upload binaries for python 3.11 to pypi when the `release` job is run.

<!--
Thank you for contributing to Robyn! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->