### PR TITLE
test: speed up tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 flake8==4.0.1
 black==21.12b0
-websockets==10.1
+websocket-client==1.4.2
 maturin==0.12.11
 isort==5.10.1
 pre-commit==2.19.0

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -39,7 +39,7 @@ def session():
     base_routes = os.path.join(current_file_path, "./base_routes.py")
     command = ["python3", base_routes]
     process = spawn_process(command)
-    time.sleep(5)
+    time.sleep(1)
     yield
     kill_process(process)
 
@@ -50,7 +50,7 @@ def default_session():
     base_routes = os.path.join(current_file_path, "./base_routes.py")
     command = ["python3", base_routes]
     process = spawn_process(command)
-    time.sleep(5)
+    time.sleep(1)
     yield
     kill_process(process)
 
@@ -75,7 +75,7 @@ def dev_session():
     base_routes = os.path.join(current_file_path, "./base_routes.py")
     command = ["python3", base_routes, "--dev"]
     process = spawn_process(command)
-    time.sleep(5)
+    time.sleep(1)
     yield
     kill_process(process)
 
@@ -88,6 +88,6 @@ def test_session():
     base_routes = os.path.join(current_file_path, "./base_routes.py")
     command = ["python3", base_routes, "--dev"]
     process = spawn_process(command)
-    time.sleep(5)
+    time.sleep(1)
     yield
     kill_process(process)

--- a/integration_tests/test_web_sockets.py
+++ b/integration_tests/test_web_sockets.py
@@ -1,19 +1,14 @@
-import asyncio
-
-from websockets import connect
+from websocket import create_connection
 
 BASE_URL = "ws://127.0.0.1:5000"
 
 
 def test_web_socket(session):
-    async def start_ws(uri):
-        async with connect(uri) as websocket:
-            assert await websocket.recv() == "Hello world, from ws"
-            await websocket.send("My name is?")
-            assert await websocket.recv() == "Whaaat??"
-            await websocket.send("My name is?")
-            assert await websocket.recv() == "Whooo??"
-            await websocket.send("My name is?")
-            assert await websocket.recv() == "*chika* *chika* Slim Shady."
-
-    asyncio.run(start_ws(f"{BASE_URL}/web_socket"))
+    ws = create_connection(f"{BASE_URL}/web_socket")
+    assert ws.recv() == "Hello world, from ws"
+    ws.send("My name is?")
+    assert ws.recv() == "Whaaat??"
+    ws.send("My name is?")
+    assert ws.recv() == "Whooo??"
+    ws.send("My name is?")
+    assert ws.recv() == "*chika* *chika* Slim Shady."

--- a/robyn/test-requirements.txt
+++ b/robyn/test-requirements.txt
@@ -4,5 +4,5 @@ watchdog
 requests==2.26.0
 uvloop==0.17.0
 multiprocess==0.70.12.2
-websockets==10.1
+websocket-client==1.4.2
 jinja2==3.0.2

--- a/src/web_socket_connection.rs
+++ b/src/web_socket_connection.rs
@@ -10,16 +10,13 @@ use pyo3_asyncio::TaskLocals;
 use uuid::Uuid;
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 /// Define HTTP actor
 #[derive(Clone)]
 struct MyWs {
     id: Uuid,
     router: HashMap<String, FunctionInfo>,
-    // can probably try removing arc from here
-    // and use clone_ref()
-    task_locals: Arc<TaskLocals>,
+    task_locals: TaskLocals,
 }
 
 fn get_function_output<'a>(
@@ -129,10 +126,8 @@ pub async fn start_web_socket(
     req: HttpRequest,
     stream: web::Payload,
     router: HashMap<String, FunctionInfo>,
-    task_locals: Arc<TaskLocals>,
+    task_locals: TaskLocals,
 ) -> Result<HttpResponse, Error> {
-    // execute the async function here
-
     ws::start(
         MyWs {
             router,


### PR DESCRIPTION
**Description**

This PR speeds up tests by a lot. On my computer, running the tests took around 40s and it now runs in around 5s.
To achieve this, I decreased the sleep time when waiting for a server, and changed the librairy used for the websocket client.
Ideally, we should wait for a signal that let us know the server has started but I could not figure out how to do that for now.
Also, I removed the `Arc` around `task_locals` in the Rust code as it seems it wasn't needed.

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->
