### PR TITLE
ci: delete the test pypi workflow 

### DIFF
--- a/.github/workflows/build-CI.yml
+++ b/.github/workflows/build-CI.yml
@@ -188,22 +188,3 @@ jobs:
         run: |
           pip install --upgrade twine
           twine upload --skip-existing *
-
-  preview_release:
-    name: Preview Release
-    runs-on: ubuntu-latest
-    needs: [macos, windows, linux, linux-cross]
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-      - name: Publish to PyPi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
-        run: |
-          pip install --upgrade twine
-          twine upload -r testpypi --skip-existing *


### PR DESCRIPTION
**Description**

This PR fixes #341 

We can download the artifacts from the jobs

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->
