### PR TITLE
chore: run tests on linux, macos and windows and release builds on ta…

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -1,17 +1,18 @@
-# CI to build the Python code
+# CI to test Robyn on major Linux, MacOS and Windows
 
 on: [push, pull_request]
 
 name: Python Continuous integration
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
+  tests:
     strategy:
+      fail-fast: false
       matrix:
+        os: ["windows", "ubuntu", "macos"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
+    name: ${{ matrix.os }} tests with python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -22,12 +23,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r robyn/test-requirements.txt
-          curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Add macos target
+        if: ${{ matrix.os }} == macos
+        run: rustup target add aarch64-apple-darwin
       - name: Setup Rust part of the project
         run: |
-          source $HOME/.cargo/env
-          maturin build -i python --release --universal2 --out dist --no-sdist
-          pip install --force-reinstall dist/robyn*.whl
+          maturin build -i python --universal2 --out dist --no-sdist
+          pip install --force-reinstall --find-links=.dist/ robyn
       - name: Test with pytest
         run: |
           pytest ./integration_tests

--- a/.github/workflows/release-CI.yml
+++ b/.github/workflows/release-CI.yml
@@ -1,10 +1,11 @@
-# CI to build the project for Linux, Windows, and MacOS
+# CI to release the project for Linux, Windows, and MacOS
 
-name: Build CI
+name: Release CI
 
 on:
   push:
-  pull_request:
+    tags:
+      - v*
 
 jobs:
   macos:
@@ -172,7 +173,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
     needs: [macos, windows, linux, linux-cross]
     steps:
       - uses: actions/download-artifact@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.26.0
 pytest==6.2.5
 maturin
-uvloop
+uvloop; platform_system!="Windows"
 watchdog
 multiprocess==0.70.12.2

--- a/robyn/test-requirements.txt
+++ b/robyn/test-requirements.txt
@@ -2,7 +2,7 @@ pytest==6.2.5
 maturin==0.12.11
 watchdog
 requests==2.26.0
-uvloop==0.17.0
+uvloop==0.17.0; platform_system!="Windows"
 multiprocess==0.70.12.2
 websocket-client==1.4.2
 jinja2==3.0.2


### PR DESCRIPTION
**Description**

This PR fixes #310

This is a proposal for a new CI/CD pipeline:
- On push and pull requests -> Run rust CI + Tests on Linux / Windows / Macos for python 3.7, 3.8, 3.9, 3.10, 3.11
- On tag creation -> Build for all OS and Python versions and upload to pypi

It seems like the tests do not pass on windows for now, adding this CI could be a good first step to fix them.