### PR TITLE
test: organize and add tests

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -1,34 +1,32 @@
-import asyncio
-import logging
 import os
 import pathlib
 
 from robyn import WS, Robyn, jsonify, serve_file, serve_html
-from robyn.log_colors import Colors
 from robyn.robyn import Response
 from robyn.templating import JinjaTemplate
 
 app = Robyn(__file__)
 websocket = WS(app, "/web_socket")
-i = -1
 
-logger = logging.getLogger(__name__)
 current_file_path = pathlib.Path(__file__).parent.resolve()
 jinja_template = JinjaTemplate(os.path.join(current_file_path, "templates"))
+
+# ===== Websockets =====
+
+websocket_state = 0
 
 
 @websocket.on("message")
 async def connect(websocket_id):
-    print(websocket_id)
-    global i
-    i += 1
-    if i == 0:
-        return "Whaaat??"
-    elif i == 1:
-        return "Whooo??"
-    elif i == 2:
-        i = -1
-        return "*chika* *chika* Slim Shady."
+    global websocket_state
+    if websocket_state == 0:
+        response = "Whaaat??"
+    elif websocket_state == 1:
+        response = "Whooo??"
+    elif websocket_state == 2:
+        response = "*chika* *chika* Slim Shady."
+    websocket_state = (websocket_state + 1) % 3
+    return response
 
 
 @websocket.on("close")
@@ -41,171 +39,7 @@ def message():
     return "Hello world, from ws"
 
 
-callCount = 0
-
-
-@app.get("/")
-async def hello(request):
-    global callCount
-    callCount += 1
-    message = "Called " + str(callCount) + " times"
-    print(message, request)
-    return {"status_code": 200, "body": "hello", "type": "text"}
-
-
-@app.get("/const_request", const=True)
-async def const_request():
-    return "Hello world"
-
-
-@app.get("/const_request_json", const=True)
-async def const_request_json():
-    return jsonify({"hello": "world"})
-
-
-@app.get("/const_request_headers", const=True)
-async def const_request_headers():
-    return {
-        "status_code": 200,
-        "body": "",
-        "type": "text",
-        "headers": {"Header": "header_value"},
-    }
-
-
-@app.get("/request_headers")
-async def request_headers():
-    return {
-        "status_code": 200,
-        "body": "This is a regular response",
-        "type": "text",
-        "headers": {"Header": "header_value"},
-    }
-
-
-@app.get("/404")
-def return_404():
-    return {"status_code": 404, "body": "hello", "type": "text"}
-
-
-@app.post("/404")
-def return_404_post():
-    return {"status_code": 404, "body": "hello", "type": "text"}
-
-
-@app.get("/int_status_code")
-def return_int_status_code():
-    return {"status_code": 202, "body": "hello", "type": "text"}
-
-
-@app.before_request("/")
-async def hello_before_request(request):
-    global callCount
-    callCount += 1
-    print(request)
-    return ""
-
-
-@app.after_request("/")
-async def hello_after_request(request):
-    global callCount
-    callCount += 1
-    print(request)
-    return ""
-
-
-@app.get("/test/:id")
-async def test(request):
-    print(request)
-    current_file_path = pathlib.Path(__file__).parent.resolve()
-    html_file = os.path.join(current_file_path, "index.html")
-
-    return serve_html(html_file)
-
-
-@app.get("/template_render")
-async def template_render():
-    context = {"framework": "Robyn", "templating_engine": "Jinja2"}
-
-    template = jinja_template.render_template(template_name="test.html", **context)
-    return template
-
-
-@app.get("/jsonify")
-async def json_get():
-    return jsonify({"hello": "world"})
-
-
-@app.get("/query")
-async def query_get(request):
-    query_data = request["queries"]
-    return jsonify(query_data)
-
-
-@app.post("/jsonify/:id")
-async def json(request):
-    return jsonify({"hello": "world"})
-
-
-@app.post("/post")
-async def post():
-    return "POST Request"
-
-
-@app.post("/post_with_body")
-async def postreq_with_body(request):
-    return bytearray(request["body"]).decode("utf-8")
-
-
-@app.put("/put")
-async def put(request):
-    return "PUT Request"
-
-
-@app.put("/put_with_body")
-async def putreq_with_body(request):
-    print(request)
-    return bytearray(request["body"]).decode("utf-8")
-
-
-@app.post("/headers")
-async def postreq_with_headers(request):
-    logger.info(f"{Colors.OKGREEN} {request['headers']} \n{Colors.ENDC}")
-    return jsonify(request["headers"])
-
-
-@app.delete("/delete")
-async def delete():
-    return "DELETE Request"
-
-
-@app.delete("/delete_with_body")
-async def deletereq_with_body(request):
-    return bytearray(request["body"]).decode("utf-8")
-
-
-@app.patch("/patch")
-async def patch():
-    return "PATCH Request"
-
-
-@app.patch("/patch_with_body")
-async def patchreq_with_body(request):
-    return bytearray(request["body"]).decode("utf-8")
-
-
-@app.get("/sleep")
-async def sleeper():
-    await asyncio.sleep(5)
-    return "sleep function"
-
-
-@app.get("/blocker")
-def blocker():
-    import time
-
-    time.sleep(10)
-    return "blocker function"
+# ===== Lifecucle handlers =====
 
 
 async def startup_handler():
@@ -217,7 +51,233 @@ def shutdown_handler():
     print("Shutting down")
 
 
-@app.get("/redirect")
+# ===== Middlewares =====
+
+
+@app.before_request("/")
+async def hello_before_request(request):
+    request["headers"]["before"] = "before_request"
+    return request
+
+
+@app.after_request("/")
+async def hello_after_request(request):
+    request["headers"]["after"] = "after_request"
+    return request
+
+
+@app.get("/")
+async def middlewares():
+    return ""
+
+
+# ===== Routes =====
+
+# --- GET ---
+
+# str
+
+
+@app.get("/sync/str")
+def sync_str_get():
+    return "sync str get"
+
+
+@app.get("/async/str")
+async def async_str_get():
+    return "async str get"
+
+
+@app.get("/sync/str/const", const=True)
+def sync_str_const_get():
+    return "sync str const get"
+
+
+@app.get("/async/str/const", const=True)
+async def async_str_const_get():
+    return "async str const get"
+
+
+# dict
+
+
+@app.get("/sync/dict")
+def sync_dict_get():
+    return {
+        "status_code": 200,
+        "body": "sync dict get",
+        "type": "text",
+        "headers": {"sync": "dict"},
+    }
+
+
+@app.get("/async/dict")
+async def async_dict_get():
+    return {
+        "status_code": 200,
+        "body": "async dict get",
+        "type": "text",
+        "headers": {"async": "dict"},
+    }
+
+
+@app.get("/sync/dict/const", const=True)
+def sync_dict_const_get():
+    return {
+        "status_code": 200,
+        "body": "sync dict const get",
+        "type": "text",
+        "headers": {"sync_const": "dict"},
+    }
+
+
+@app.get("/async/dict/const", const=True)
+async def async_dict_const_get():
+    return {
+        "status_code": 200,
+        "body": "async dict const get",
+        "type": "text",
+        "headers": {"async_const": "dict"},
+    }
+
+
+# Response
+
+
+@app.get("/sync/response")
+def sync_response_get():
+    return Response(200, {"sync": "response"}, "sync response get")
+
+
+@app.get("/async/response")
+async def async_response_get():
+    return Response(200, {"async": "response"}, "async response get")
+
+
+@app.get("/sync/response/const", const=True)
+def sync_response_const_get():
+    return Response(200, {"sync_const": "response"}, "sync response const get")
+
+
+@app.get("/async/response/const", const=True)
+async def async_response_const_get():
+    return Response(200, {"async_const": "response"}, "async response const get")
+
+
+# JSON
+
+
+@app.get("/sync/json")
+def sync_json_get():
+    return jsonify({"sync json get": "json"})
+
+
+@app.get("/async/json")
+async def async_json_get():
+    return jsonify({"async json get": "json"})
+
+
+@app.get("/sync/json/const", const=True)
+def sync_json_const_get():
+    return jsonify({"sync json const get": "json"})
+
+
+@app.get("/async/json/const", const=True)
+async def async_json_const_get():
+    return jsonify({"async json const get": "json"})
+
+
+# Param
+
+
+@app.get("/sync/param/:id")
+def sync_param(request):
+    id = request["params"]["id"]
+    return id
+
+
+@app.get("/async/param/:id")
+async def async_param(request):
+    id = request["params"]["id"]
+    return id
+
+
+# HTML serving
+
+
+@app.get("/sync/serve/html")
+def sync_serve_html():
+    html_file = os.path.join(current_file_path, "index.html")
+    return serve_html(html_file)
+
+
+@app.get("/async/serve/html")
+async def async_serve_html():
+    html_file = os.path.join(current_file_path, "index.html")
+    return serve_html(html_file)
+
+
+# Template
+
+
+@app.get("/sync/template")
+def sync_template_render():
+    context = {"framework": "Robyn", "templating_engine": "Jinja2"}
+    template = jinja_template.render_template(template_name="test.html", **context)
+    return template
+
+
+@app.get("/async/template")
+async def async_template_render():
+    context = {"framework": "Robyn", "templating_engine": "Jinja2"}
+    template = jinja_template.render_template(template_name="test.html", **context)
+    return template
+
+
+# File download
+
+
+@app.get("/sync/file/download")
+def sync_file_download():
+    file_path = os.path.join(current_file_path, "downloads", "test.txt")
+    return serve_file(file_path)
+
+
+@app.get("/async/file/download")
+async def file_download_async():
+    file_path = os.path.join(current_file_path, "downloads", "test.txt")
+    return serve_file(file_path)
+
+
+# Queries
+
+
+@app.get("/sync/queries")
+def sync_queries(request):
+    query_data = request["queries"]
+    return jsonify(query_data)
+
+
+@app.get("/async/queries")
+async def async_query(request):
+    query_data = request["queries"]
+    return jsonify(query_data)
+
+
+# Status code
+
+
+@app.get("/404")
+def return_404():
+    return {"status_code": 404, "body": "not found", "type": "text"}
+
+
+@app.get("/202")
+def return_202():
+    return {"status_code": 202, "body": "hello", "type": "text"}
+
+
+@app.get("/307")
 async def redirect(request):
     return {
         "status_code": 307,
@@ -232,48 +292,159 @@ async def redirect_route(request):
     return "This is the redirected route"
 
 
-@app.get("/types/response")
-def response_type(request):
-    return Response(status_code=200, headers={}, body="OK")
+# --- POST ---
+
+# dict
 
 
-@app.get("/types/str")
-def str_type(request):
-    return "OK"
+@app.post("/sync/dict")
+def sync_dict_post():
+    return {
+        "status_code": 200,
+        "body": "sync dict post",
+        "type": "text",
+        "headers": {"sync": "dict"},
+    }
 
 
-@app.get("/types/int")
-def int_type(request):
-    return 0
+@app.post("/async/dict")
+async def async_dict_post():
+    return {
+        "status_code": 200,
+        "body": "async dict post",
+        "type": "text",
+        "headers": {"async": "dict"},
+    }
 
 
-@app.get("/async/types/response")
-async def async_response_type(request):
-    return Response(status_code=200, headers={}, body="OK")
+# Body
 
 
-@app.get("/async/types/str")
-async def async_str_type(request):
-    return "OK"
+@app.post("/sync/body")
+def sync_body_post(request):
+    return bytearray(request["body"]).decode("utf-8")
 
 
-@app.get("/async/types/int")
-async def async_int_type(request):
-    return 0
+@app.post("/async/body")
+async def async_body_post(request):
+    return bytearray(request["body"]).decode("utf-8")
 
 
-@app.get("/file_download_sync")
-def file_download_sync():
-    current_file_path = pathlib.Path(__file__).parent.resolve()
-    file_path = os.path.join(current_file_path, "downloads", "test.txt")
-    return serve_file(file_path)
+# --- PUT ---
+
+# dict
 
 
-@app.get("/file_download_async")
-def file_download_async():
-    current_file_path = pathlib.Path(__file__).parent.resolve()
-    file_path = os.path.join(current_file_path, "downloads", "test.txt")
-    return serve_file(file_path)
+@app.put("/sync/dict")
+def sync_dict_put():
+    return {
+        "status_code": 200,
+        "body": "sync dict put",
+        "type": "text",
+        "headers": {"sync": "dict"},
+    }
+
+
+@app.put("/async/dict")
+async def async_dict_put():
+    return {
+        "status_code": 200,
+        "body": "async dict put",
+        "type": "text",
+        "headers": {"async": "dict"},
+    }
+
+
+# Body
+
+
+@app.put("/sync/body")
+def sync_body_put(request):
+    return bytearray(request["body"]).decode("utf-8")
+
+
+@app.put("/async/body")
+async def async_body_put(request):
+    return bytearray(request["body"]).decode("utf-8")
+
+
+# --- DELETE ---
+
+# dict
+
+
+@app.delete("/sync/dict")
+def sync_dict_delete():
+    return {
+        "status_code": 200,
+        "body": "sync dict delete",
+        "type": "text",
+        "headers": {"sync": "dict"},
+    }
+
+
+@app.delete("/async/dict")
+async def async_dict_delete():
+    return {
+        "status_code": 200,
+        "body": "async dict delete",
+        "type": "text",
+        "headers": {"async": "dict"},
+    }
+
+
+# Body
+
+
+@app.delete("/sync/body")
+def sync_body_delete(request):
+    return bytearray(request["body"]).decode("utf-8")
+
+
+@app.delete("/async/body")
+async def async_body_delete(request):
+    return bytearray(request["body"]).decode("utf-8")
+
+
+# --- PATCH ---
+
+# dict
+
+
+@app.patch("/sync/dict")
+def sync_dict_patch():
+    return {
+        "status_code": 200,
+        "body": "sync dict patch",
+        "type": "text",
+        "headers": {"sync": "dict"},
+    }
+
+
+@app.patch("/async/dict")
+async def async_dict_patch():
+    return {
+        "status_code": 200,
+        "body": "async dict patch",
+        "type": "text",
+        "headers": {"async": "dict"},
+    }
+
+
+# Body
+
+
+@app.patch("/sync/body")
+def sync_body_patch(request):
+    return bytearray(request["body"]).decode("utf-8")
+
+
+@app.patch("/async/body")
+async def async_body_patch(request):
+    return bytearray(request["body"]).decode("utf-8")
+
+
+# ===== Main =====
 
 
 @app.get("/sync/raise")
@@ -288,7 +459,6 @@ async def async_raise():
 
 if __name__ == "__main__":
     app.add_request_header("server", "robyn")
-    current_file_path = pathlib.Path(__file__).parent.resolve()
     app.add_directory(
         route="/test_dir",
         directory_path=os.path.join(current_file_path, "build"),

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -39,7 +39,7 @@ def message():
     return "Hello world, from ws"
 
 
-# ===== Lifecucle handlers =====
+# ===== Lifecycle handlers =====
 
 
 async def startup_handler():

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -112,3 +112,17 @@ def test_session():
     process = start_server(domain, port, is_dev=True)
     yield
     kill_process(process)
+
+
+# create robyn.env before test and delete it after test
+@pytest.fixture
+def env_file():
+    CONTENT = """ROBYN_PORT=8081
+    ROBYN_URL=127.0.0.1"""
+    path = pathlib.Path(__file__).parent
+    env_path = path / "robyn.env"
+    env_path.write_text(CONTENT)
+    yield
+    env_path.unlink()
+    os.unsetenv("ROBYN_PORT")
+    os.unsetenv("ROBYN_URL")

--- a/integration_tests/http_methods_helpers.py
+++ b/integration_tests/http_methods_helpers.py
@@ -1,6 +1,6 @@
 from typing import Optional
-import requests
 
+import requests
 
 BASE_URL = "http://127.0.0.1:8080"
 

--- a/integration_tests/test_app.py
+++ b/integration_tests/test_app.py
@@ -1,0 +1,33 @@
+from robyn import Robyn
+from robyn.events import Events
+from robyn.types import Header
+
+
+def test_add_request_header():
+    app = Robyn(__file__)
+    app.add_request_header("server", "robyn")
+    assert app.request_headers == [Header(key="server", val="robyn")]
+
+
+def test_lifecycle_handlers():
+    def mock_startup_handler():
+        pass
+
+    async def mock_shutdown_handler():
+        pass
+
+    app = Robyn(__file__)
+
+    app.startup_handler(mock_startup_handler)
+    assert Events.STARTUP in app.event_handlers
+    startup = app.event_handlers[Events.STARTUP]
+    assert startup.handler == mock_startup_handler
+    assert startup.is_async is False
+    assert startup.number_of_params == 0
+
+    app.shutdown_handler(mock_shutdown_handler)
+    assert Events.SHUTDOWN in app.event_handlers
+    shutdown = app.event_handlers[Events.SHUTDOWN]
+    assert shutdown.handler == mock_shutdown_handler
+    assert shutdown.is_async is True
+    assert shutdown.number_of_params == 0

--- a/integration_tests/test_base_url.py
+++ b/integration_tests/test_base_url.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 
 

--- a/integration_tests/test_basic_routes.py
+++ b/integration_tests/test_basic_routes.py
@@ -2,72 +2,61 @@
 # - the GET method
 # - most common return types
 # - sync and async
-# The syntax for the routes dict is `route: (expected_body, expected_header_key, expected_header_value)`
 
-from utils import get
+from typing import Optional
 
-SYNC_ROUTES = {
-    "/sync/str": ("sync str", None, None),
-    "/sync/dict": ("sync dict", "sync", "dict"),
-    "/sync/response": ("sync response", "sync", "response"),
-}
+import pytest
 
-SYNC_ROUTES_CONST = {
-    "/sync/str/const": ("sync str const", None, None),
-    "/sync/dict/const": ("sync dict const", "sync_const", "dict"),
-    "/sync/response/const": ("sync response const", "sync_const", "response"),
-}
-
-ASYNC_ROUTES = {
-    "/async/str": ("async str", None, None),
-    "/async/dict": ("async dict", "async", "dict"),
-    "/async/response": ("async response", "async", "response"),
-}
-
-ASYNC_ROUTES_CONST = {
-    "/async/str/const": ("async str const", None, None),
-    "/async/dict/const": ("async dict const", "async_const", "dict"),
-    "/async/response/const": ("async response const", "async_const", "response"),
-}
-
-JSON_ROUTES = {
-    "/sync/json": {"sync json": "json"},
-    "/async/json": {"async json": "json"},
-}
-
-JSON_ROUTES_CONST = {
-    "/sync/json/const": {"sync json const": "json"},
-    "/async/json/const": {"async json const": "json"},
-}
+from http_methods_helpers import get
 
 
-def test_sync_get(session):
-    routes = SYNC_ROUTES
-    routes.update(SYNC_ROUTES_CONST)
-    for route, expected in routes.items():
-        res = get(route)
-        assert res.text == expected[0] + " get"
-        if expected[1] is not None:
-            assert expected[1] in res.headers
-            assert res.headers[expected[1]] == expected[2]
+@pytest.mark.parametrize(
+    "route,expected_text,expected_header_key,expected_header_value",
+    [
+        ("/sync/str", "sync str get", None, None),
+        ("/sync/dict", "sync dict get", "sync", "dict"),
+        ("/sync/response", "sync response get", "sync", "response"),
+        ("/sync/str/const", "sync str const get", None, None),
+        ("/sync/dict/const", "sync dict const get", "sync_const", "dict"),
+        ("/sync/response/const", "sync response const get", "sync_const", "response"),
+        ("/async/str", "async str get", None, None),
+        ("/async/dict", "async dict get", "async", "dict"),
+        ("/async/response", "async response get", "async", "response"),
+        ("/async/str/const", "async str const get", None, None),
+        ("/async/dict/const", "async dict const get", "async_const", "dict"),
+        (
+            "/async/response/const",
+            "async response const get",
+            "async_const",
+            "response",
+        ),
+    ],
+)
+def test_basic_get(
+    route: str,
+    expected_text: str,
+    expected_header_key: Optional[str],
+    expected_header_value: Optional[str],
+    session,
+):
+    res = get(route)
+    assert res.text == expected_text
+    if expected_header_key is not None:
+        assert expected_header_key in res.headers
+        assert res.headers[expected_header_key] == expected_header_value
 
 
-def test_async_get(session):
-    routes = ASYNC_ROUTES
-    routes.update(ASYNC_ROUTES_CONST)
-    for route, expected in routes.items():
-        res = get(route)
-        assert res.text == expected[0] + " get"
-        if expected[1] is not None:
-            assert expected[1] in res.headers
-            assert res.headers[expected[1]] == expected[2]
-
-
-def test_json_get(session):
-    routes = JSON_ROUTES
-    routes.update(JSON_ROUTES_CONST)
-    for route, expected in routes.items():
-        res = get(route)
-        for key in expected.keys():
-            assert key + " get" in res.json()
-            assert res.json()[key + " get"] == expected[key]
+@pytest.mark.parametrize(
+    "route, expected_json",
+    [
+        ("/sync/json", {"sync json get": "json"}),
+        ("/async/json", {"async json get": "json"}),
+        ("/sync/json/const", {"sync json const get": "json"}),
+        ("/async/json/const", {"async json const get": "json"}),
+    ],
+)
+def test_json_get(route: str, expected_json: dict, session):
+    res = get(route)
+    for key in expected_json.keys():
+        assert key in res.json()
+        assert res.json()[key] == expected_json[key]

--- a/integration_tests/test_basic_routes.py
+++ b/integration_tests/test_basic_routes.py
@@ -1,0 +1,73 @@
+# Test the routes with:
+# - the GET method
+# - most common return types
+# - sync and async
+# The syntax for the routes dict is `route: (expected_body, expected_header_key, expected_header_value)`
+
+from utils import get
+
+SYNC_ROUTES = {
+    "/sync/str": ("sync str", None, None),
+    "/sync/dict": ("sync dict", "sync", "dict"),
+    "/sync/response": ("sync response", "sync", "response"),
+}
+
+SYNC_ROUTES_CONST = {
+    "/sync/str/const": ("sync str const", None, None),
+    "/sync/dict/const": ("sync dict const", "sync_const", "dict"),
+    "/sync/response/const": ("sync response const", "sync_const", "response"),
+}
+
+ASYNC_ROUTES = {
+    "/async/str": ("async str", None, None),
+    "/async/dict": ("async dict", "async", "dict"),
+    "/async/response": ("async response", "async", "response"),
+}
+
+ASYNC_ROUTES_CONST = {
+    "/async/str/const": ("async str const", None, None),
+    "/async/dict/const": ("async dict const", "async_const", "dict"),
+    "/async/response/const": ("async response const", "async_const", "response"),
+}
+
+JSON_ROUTES = {
+    "/sync/json": {"sync json": "json"},
+    "/async/json": {"async json": "json"},
+}
+
+JSON_ROUTES_CONST = {
+    "/sync/json/const": {"sync json const": "json"},
+    "/async/json/const": {"async json const": "json"},
+}
+
+
+def test_sync_get(session):
+    routes = SYNC_ROUTES
+    routes.update(SYNC_ROUTES_CONST)
+    for route, expected in routes.items():
+        res = get(route)
+        assert res.text == expected[0] + " get"
+        if expected[1] is not None:
+            assert expected[1] in res.headers
+            assert res.headers[expected[1]] == expected[2]
+
+
+def test_async_get(session):
+    routes = ASYNC_ROUTES
+    routes.update(ASYNC_ROUTES_CONST)
+    for route, expected in routes.items():
+        res = get(route)
+        assert res.text == expected[0] + " get"
+        if expected[1] is not None:
+            assert expected[1] in res.headers
+            assert res.headers[expected[1]] == expected[2]
+
+
+def test_json_get(session):
+    routes = JSON_ROUTES
+    routes.update(JSON_ROUTES_CONST)
+    for route, expected in routes.items():
+        res = get(route)
+        for key in expected.keys():
+            assert key + " get" in res.json()
+            assert res.json()[key + " get"] == expected[key]

--- a/integration_tests/test_delete_requests.py
+++ b/integration_tests/test_delete_requests.py
@@ -1,19 +1,16 @@
+import pytest
 from http_methods_helpers import delete
 
 
-def test_delete(session):
-    res = delete("/sync/dict")
-    assert res.text == "sync dict delete"
-    assert "sync" in res.headers
-    assert res.headers["sync"] == "dict"
-    res = delete("/async/dict")
-    assert res.text == "async dict delete"
-    assert "async" in res.headers
-    assert res.headers["async"] == "dict"
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_delete(function_type: str, session):
+    res = delete(f"/{function_type}/dict")
+    assert res.text == f"{function_type} dict delete"
+    assert function_type in res.headers
+    assert res.headers[function_type] == "dict"
 
 
-def test_delete_with_param(session):
-    res = delete("/sync/body", data={"hello": "world"})
-    assert res.text == "hello=world"
-    res = delete("/async/body", data={"hello": "world"})
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_delete_with_param(function_type: str, session):
+    res = delete(f"/{function_type}/body", data={"hello": "world"})
     assert res.text == "hello=world"

--- a/integration_tests/test_delete_requests.py
+++ b/integration_tests/test_delete_requests.py
@@ -1,15 +1,19 @@
-import requests
-
-BASE_URL = "http://127.0.0.1:8080"
+from utils import delete
 
 
 def test_delete(session):
-    res = requests.delete(f"{BASE_URL}/delete")
-    assert res.status_code == 200
-    assert res.text == "DELETE Request"
+    res = delete("/sync/dict")
+    assert res.text == "sync dict delete"
+    assert "sync" in res.headers
+    assert res.headers["sync"] == "dict"
+    res = delete("/async/dict")
+    assert res.text == "async dict delete"
+    assert "async" in res.headers
+    assert res.headers["async"] == "dict"
 
 
 def test_delete_with_param(session):
-    res = requests.delete(f"{BASE_URL}/delete_with_body", data={"hello": "world"})
-    assert res.status_code == 200
+    res = delete("/sync/body", data={"hello": "world"})
+    assert res.text == "hello=world"
+    res = delete("/async/body", data={"hello": "world"})
     assert res.text == "hello=world"

--- a/integration_tests/test_delete_requests.py
+++ b/integration_tests/test_delete_requests.py
@@ -1,4 +1,4 @@
-from utils import delete
+from http_methods_helpers import delete
 
 
 def test_delete(session):

--- a/integration_tests/test_env_populator.py
+++ b/integration_tests/test_env_populator.py
@@ -1,29 +1,12 @@
-# from integration_tests.conftest import test_session
 import os
 import pathlib
 
-import pytest
-
 from robyn.env_populator import load_vars, parser
-
-path = pathlib.Path(__file__).parent
-
-
-# create robyn.env before test and delete it after test
-@pytest.fixture
-def env_file():
-    CONTENT = """ROBYN_PORT=8081
-    ROBYN_URL=127.0.0.1"""
-    env_path = path / "robyn.env"
-    env_path.write_text(CONTENT)
-    yield
-    env_path.unlink()
-    os.unsetenv("ROBYN_PORT")
-    os.unsetenv("ROBYN_URL")
 
 
 # this tests if a connection can be made to the server with the correct port imported from the env file
 def test_env_population(test_session, env_file):
+    path = pathlib.Path(__file__).parent
     env_path = path / "robyn.env"
     load_vars(variables=parser(config_path=env_path))
     PORT = os.environ["ROBYN_PORT"]

--- a/integration_tests/test_file_download.py
+++ b/integration_tests/test_file_download.py
@@ -1,13 +1,9 @@
+import pytest
 from http_methods_helpers import get
 
 
-def test_file_download_sync(session):
-    r = get("/sync/file/download")
-    assert r.headers["Content-Disposition"] == "attachment"
-    assert r.text == "This is a test file for the downloading purpose\n"
-
-
-def test_file_download_async(session):
-    r = get("/async/file/download")
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_file_download(function_type: str, session):
+    r = get(f"/{function_type}/file/download")
     assert r.headers["Content-Disposition"] == "attachment"
     assert r.text == "This is a test file for the downloading purpose\n"

--- a/integration_tests/test_file_download.py
+++ b/integration_tests/test_file_download.py
@@ -1,17 +1,13 @@
-import requests
-
-BASE_URL = "http://127.0.0.1:8080"
+from utils import get
 
 
 def test_file_download_sync(session):
-    r = requests.get(f"{BASE_URL}/file_download_sync")
-    assert r.status_code == 200
+    r = get("/sync/file/download")
     assert r.headers["Content-Disposition"] == "attachment"
     assert r.text == "This is a test file for the downloading purpose\n"
 
 
 def test_file_download_async(session):
-    r = requests.get(f"{BASE_URL}/file_download_async")
-    assert r.status_code == 200
+    r = get("/async/file/download")
     assert r.headers["Content-Disposition"] == "attachment"
     assert r.text == "This is a test file for the downloading purpose\n"

--- a/integration_tests/test_file_download.py
+++ b/integration_tests/test_file_download.py
@@ -1,4 +1,4 @@
-from utils import get
+from http_methods_helpers import get
 
 
 def test_file_download_sync(session):

--- a/integration_tests/test_get_requests.py
+++ b/integration_tests/test_get_requests.py
@@ -1,5 +1,6 @@
 from requests import Response
-from utils import get
+
+from http_methods_helpers import get
 
 
 def test_param(session):

--- a/integration_tests/test_get_requests.py
+++ b/integration_tests/test_get_requests.py
@@ -1,96 +1,46 @@
-import requests
-
-BASE_URL = "http://127.0.0.1:8080"
-
-
-def test_index_request(session):
-    res = requests.get(f"{BASE_URL}")
-    assert res.status_code == 200
+from requests import Response
+from utils import get
 
 
-def test_jsonify(session):
-    r = requests.get(f"{BASE_URL}/jsonify")
-    assert r.json() == {"hello": "world"}
-    assert r.status_code == 200
+def test_param(session):
+    r = get("/sync/param/1")
+    assert r.text == "1"
+    r = get("/sync/param/12345")
+    assert r.text == "12345"
+    r = get("/async/param/1")
+    assert r.text == "1"
+    r = get("/async/param/12345")
+    assert r.text == "12345"
 
 
-def test_html(session):
-    r = requests.get(f"{BASE_URL}/test/123")
-    assert "Hello world. How are you?" in r.text
+def test_serve_html(session):
+    def check_response(r: Response):
+        assert r.text.startswith("<!DOCTYPE html>")
+        assert "Hello world. How are you?" in r.text
+
+    check_response(get("/sync/serve/html"))
+    check_response(get("/async/serve/html"))
 
 
-def test_jinja_template(session):
-    r = requests.get(f"{BASE_URL}/template_render")
-    assert "Jinja2" in r.text
-    assert "Robyn" in r.text
+def test_template(session):
+    def check_response(r: Response):
+        assert r.text.startswith("\n\n<!DOCTYPE html>")
+        assert "Jinja2" in r.text
+        assert "Robyn" in r.text
+
+    check_response(get("/sync/template"))
+    check_response(get("/async/template"))
 
 
 def test_queries(session):
-    r = requests.get(f"{BASE_URL}/query?hello=robyn")
+    r = get("/sync/queries?hello=robyn")
     assert r.json() == {"hello": "robyn"}
 
-    r = requests.get(f"{BASE_URL}/query")
+    r = get("/sync/queries")
     assert r.json() == {}
 
+    r = get("/async/queries?hello=robyn")
+    assert r.json() == {"hello": "robyn"}
 
-def test_request_headers(session):
-    r = requests.get(f"{BASE_URL}/request_headers")
-    assert r.status_code == 200
-    assert r.text == "This is a regular response"
-    assert "Header" in r.headers
-    assert r.headers["Header"] == "header_value"
-
-
-def test_const_request(session):
-    r = requests.get(f"{BASE_URL}/const_request")
-    assert "Hello world" in r.text
-    assert r.status_code == 200
-
-
-def test_const_request_json(session):
-    r = requests.get(f"{BASE_URL}/const_request_json")
-    assert r.status_code == 200
-    assert r.json() == {"hello": "world"}
-
-
-def test_const_request_headers(session):
-    r = requests.get(f"{BASE_URL}/const_request_headers")
-    assert r.status_code == 200
-    assert "Header" in r.headers
-    assert r.headers["Header"] == "header_value"
-
-
-def test_response_type(session):
-    r = requests.get(f"{BASE_URL}/types/response")
-    assert r.status_code == 200
-    assert r.text == "OK"
-
-
-def test_str_type(session):
-    r = requests.get(f"{BASE_URL}/types/str")
-    assert r.status_code == 200
-    assert r.text == "OK"
-
-
-def test_int_type(session):
-    r = requests.get(f"{BASE_URL}/types/int")
-    assert r.status_code == 200
-    assert r.text == "0"
-
-
-def test_async_response_type(session):
-    r = requests.get(f"{BASE_URL}/async/types/response")
-    assert r.status_code == 200
-    assert r.text == "OK"
-
-
-def test_async_str_type(session):
-    r = requests.get(f"{BASE_URL}/async/types/str")
-    assert r.status_code == 200
-    assert r.text == "OK"
-
-
-def test_async_int_type(session):
-    r = requests.get(f"{BASE_URL}/async/types/int")
-    assert r.status_code == 200
-    assert r.text == "0"
+    r = get("/async/queries")
+    assert r.json() == {}

--- a/integration_tests/test_get_requests.py
+++ b/integration_tests/test_get_requests.py
@@ -1,47 +1,40 @@
+import pytest
 from requests import Response
 
 from http_methods_helpers import get
 
 
-def test_param(session):
-    r = get("/sync/param/1")
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_param(function_type: str, session):
+    r = get(f"/{function_type}/param/1")
     assert r.text == "1"
-    r = get("/sync/param/12345")
-    assert r.text == "12345"
-    r = get("/async/param/1")
-    assert r.text == "1"
-    r = get("/async/param/12345")
+    r = get(f"/{function_type}/param/12345")
     assert r.text == "12345"
 
 
-def test_serve_html(session):
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_serve_html(function_type: str, session):
     def check_response(r: Response):
         assert r.text.startswith("<!DOCTYPE html>")
         assert "Hello world. How are you?" in r.text
 
-    check_response(get("/sync/serve/html"))
-    check_response(get("/async/serve/html"))
+    check_response(get(f"/{function_type}/serve/html"))
 
 
-def test_template(session):
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_template(function_type: str, session):
     def check_response(r: Response):
         assert r.text.startswith("\n\n<!DOCTYPE html>")
         assert "Jinja2" in r.text
         assert "Robyn" in r.text
 
-    check_response(get("/sync/template"))
-    check_response(get("/async/template"))
+    check_response(get(f"/{function_type}/template"))
 
 
-def test_queries(session):
-    r = get("/sync/queries?hello=robyn")
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_queries(function_type: str, session):
+    r = get(f"/{function_type}/queries?hello=robyn")
     assert r.json() == {"hello": "robyn"}
 
-    r = get("/sync/queries")
-    assert r.json() == {}
-
-    r = get("/async/queries?hello=robyn")
-    assert r.json() == {"hello": "robyn"}
-
-    r = get("/async/queries")
+    r = get(f"/{function_type}/queries")
     assert r.json() == {}

--- a/integration_tests/test_middlewares.py
+++ b/integration_tests/test_middlewares.py
@@ -1,0 +1,11 @@
+import pytest
+from utils import get
+
+
+@pytest.mark.skip(reason="Fix middleware request headers modification")
+def test_middlewares(session):
+    r = get("/")
+    assert "before" in r.headers
+    assert r.headers["before"] == "before_request"
+    assert "after" in r.headers
+    assert r.headers["after"] == "after_request"

--- a/integration_tests/test_middlewares.py
+++ b/integration_tests/test_middlewares.py
@@ -1,5 +1,6 @@
 import pytest
-from utils import get
+
+from http_methods_helpers import get
 
 
 @pytest.mark.skip(reason="Fix middleware request headers modification")

--- a/integration_tests/test_patch_requests.py
+++ b/integration_tests/test_patch_requests.py
@@ -1,15 +1,19 @@
-import requests
-
-BASE_URL = "http://127.0.0.1:8080"
+from utils import patch
 
 
 def test_patch(session):
-    res = requests.patch(f"{BASE_URL}/patch")
-    assert res.status_code == 200
-    assert res.text == "PATCH Request"
+    res = patch("/sync/dict")
+    assert res.text == "sync dict patch"
+    assert "sync" in res.headers
+    assert res.headers["sync"] == "dict"
+    res = patch("/async/dict")
+    assert res.text == "async dict patch"
+    assert "async" in res.headers
+    assert res.headers["async"] == "dict"
 
 
 def test_patch_with_param(session):
-    res = requests.patch(f"{BASE_URL}/patch_with_body", data={"hello": "world"})
-    assert res.status_code == 200
+    res = patch("/sync/body", data={"hello": "world"})
+    assert res.text == "hello=world"
+    res = patch("/async/body", data={"hello": "world"})
     assert res.text == "hello=world"

--- a/integration_tests/test_patch_requests.py
+++ b/integration_tests/test_patch_requests.py
@@ -1,4 +1,4 @@
-from utils import patch
+from http_methods_helpers import patch
 
 
 def test_patch(session):

--- a/integration_tests/test_patch_requests.py
+++ b/integration_tests/test_patch_requests.py
@@ -1,19 +1,16 @@
+import pytest
 from http_methods_helpers import patch
 
 
-def test_patch(session):
-    res = patch("/sync/dict")
-    assert res.text == "sync dict patch"
-    assert "sync" in res.headers
-    assert res.headers["sync"] == "dict"
-    res = patch("/async/dict")
-    assert res.text == "async dict patch"
-    assert "async" in res.headers
-    assert res.headers["async"] == "dict"
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_patch(function_type: str, session):
+    res = patch(f"/{function_type}/dict")
+    assert res.text == f"{function_type} dict patch"
+    assert function_type in res.headers
+    assert res.headers[function_type] == "dict"
 
 
-def test_patch_with_param(session):
-    res = patch("/sync/body", data={"hello": "world"})
-    assert res.text == "hello=world"
-    res = patch("/async/body", data={"hello": "world"})
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_patch_with_param(function_type: str, session):
+    res = patch(f"/{function_type}/body", data={"hello": "world"})
     assert res.text == "hello=world"

--- a/integration_tests/test_post_requests.py
+++ b/integration_tests/test_post_requests.py
@@ -1,4 +1,4 @@
-from utils import post
+from http_methods_helpers import post
 
 
 def test_post(session):

--- a/integration_tests/test_post_requests.py
+++ b/integration_tests/test_post_requests.py
@@ -1,19 +1,16 @@
+import pytest
 from http_methods_helpers import post
 
 
-def test_post(session):
-    res = post("/sync/dict")
-    assert res.text == "sync dict post"
-    assert "sync" in res.headers
-    assert res.headers["sync"] == "dict"
-    res = post("/async/dict")
-    assert res.text == "async dict post"
-    assert "async" in res.headers
-    assert res.headers["async"] == "dict"
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_post(function_type: str, session):
+    res = post(f"/{function_type}/dict")
+    assert res.text == f"{function_type} dict post"
+    assert function_type in res.headers
+    assert res.headers[function_type] == "dict"
 
 
-def test_post_with_param(session):
-    res = post("/sync/body", data={"hello": "world"})
-    assert res.text == "hello=world"
-    res = post("/async/body", data={"hello": "world"})
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_post_with_param(function_type: str, session):
+    res = post(f"/{function_type}/body", data={"hello": "world"})
     assert res.text == "hello=world"

--- a/integration_tests/test_post_requests.py
+++ b/integration_tests/test_post_requests.py
@@ -1,27 +1,19 @@
-import requests
-
-BASE_URL = "http://127.0.0.1:8080"
+from utils import post
 
 
 def test_post(session):
-    res = requests.post(f"{BASE_URL}/post")
-    assert res.status_code == 200
-    assert res.text == "POST Request"
+    res = post("/sync/dict")
+    assert res.text == "sync dict post"
+    assert "sync" in res.headers
+    assert res.headers["sync"] == "dict"
+    res = post("/async/dict")
+    assert res.text == "async dict post"
+    assert "async" in res.headers
+    assert res.headers["async"] == "dict"
 
 
 def test_post_with_param(session):
-    res = requests.post(f"{BASE_URL}/post_with_body", data={"hello": "world"})
+    res = post("/sync/body", data={"hello": "world"})
     assert res.text == "hello=world"
-    assert res.status_code == 200
-
-
-def test_jsonify_request(session):
-    res = requests.post(f"{BASE_URL}/jsonify/123")
-    assert res.status_code == 200
-    assert res.json() == {"hello": "world"}
-
-
-def test_post_request_headers(session):
-    res = requests.post(f"{BASE_URL}/headers", headers={"hello": "world"})
-    assert res.status_code == 200
-    assert res.json()["hello"] == "world"
+    res = post("/async/body", data={"hello": "world"})
+    assert res.text == "hello=world"

--- a/integration_tests/test_put_requests.py
+++ b/integration_tests/test_put_requests.py
@@ -1,4 +1,4 @@
-from utils import put
+from http_methods_helpers import put
 
 
 def test_put(session):

--- a/integration_tests/test_put_requests.py
+++ b/integration_tests/test_put_requests.py
@@ -1,16 +1,19 @@
-import requests
-
-BASE_URL = "http://127.0.0.1:8080"
+from utils import put
 
 
 def test_put(session):
-    res = requests.put(f"{BASE_URL}/put")
-    assert res.status_code == 200
-    assert res.text == "PUT Request"
+    res = put("/sync/dict")
+    assert res.text == "sync dict put"
+    assert "sync" in res.headers
+    assert res.headers["sync"] == "dict"
+    res = put("/async/dict")
+    assert res.text == "async dict put"
+    assert "async" in res.headers
+    assert res.headers["async"] == "dict"
 
 
 def test_put_with_param(session):
-    res = requests.put(f"{BASE_URL}/put_with_body", data={"hello": "world"})
-
-    assert res.status_code == 200
+    res = put("/sync/body", data={"hello": "world"})
+    assert res.text == "hello=world"
+    res = put("/async/body", data={"hello": "world"})
     assert res.text == "hello=world"

--- a/integration_tests/test_put_requests.py
+++ b/integration_tests/test_put_requests.py
@@ -1,19 +1,16 @@
+import pytest
 from http_methods_helpers import put
 
 
-def test_put(session):
-    res = put("/sync/dict")
-    assert res.text == "sync dict put"
-    assert "sync" in res.headers
-    assert res.headers["sync"] == "dict"
-    res = put("/async/dict")
-    assert res.text == "async dict put"
-    assert "async" in res.headers
-    assert res.headers["async"] == "dict"
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_put(function_type: str, session):
+    res = put(f"/{function_type}/dict")
+    assert res.text == f"{function_type} dict put"
+    assert function_type in res.headers
+    assert res.headers[function_type] == "dict"
 
 
-def test_put_with_param(session):
-    res = put("/sync/body", data={"hello": "world"})
-    assert res.text == "hello=world"
-    res = put("/async/body", data={"hello": "world"})
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_put_with_param(function_type: str, session):
+    res = put(f"/{function_type}/body", data={"hello": "world"})
     assert res.text == "hello=world"

--- a/integration_tests/test_status_code.py
+++ b/integration_tests/test_status_code.py
@@ -1,39 +1,22 @@
-import requests
-
-BASE_URL = "http://127.0.0.1:8080"
+from utils import get
 
 
 def test_404_status_code(session):
-    res = requests.get(f"{BASE_URL}/404")
-    assert res.status_code == 404
-
-
-def test_404_post_request_status_code(session):
-    r = requests.post(f"{BASE_URL}/404")
-    assert r.status_code == 404
+    get("/404", expected_status_code=404)
 
 
 def test_404_not_found(session):
-    r = requests.get(f"{BASE_URL}/actually_not_found_route")
-    assert r.status_code == 404
+    r = get("/real/404", expected_status_code=404)
     assert r.text == "Not found"
 
 
-def test_307_get_request(session):
-    r = requests.get(f"{BASE_URL}/redirect")
-    assert r.text == "This is the redirected route"
-
-
-def test_int_status_code(session):
-    r = requests.get(f"{BASE_URL}/int_status_code")
-    assert r.status_code == 202
+def test_202_status_code(session):
+    get("/202", expected_status_code=202)
 
 
 def test_sync_500_internal_server_error(session):
-    r = requests.get(f"{BASE_URL}/sync/raise")
-    assert r.status_code == 500
+    get("/sync/raise", expected_status_code=500)
 
 
 def test_async_500_internal_server_error(session):
-    r = requests.get(f"{BASE_URL}/async/raise")
-    assert r.status_code == 500
+    get("/async/raise", expected_status_code=500)

--- a/integration_tests/test_status_code.py
+++ b/integration_tests/test_status_code.py
@@ -1,3 +1,4 @@
+import pytest
 from http_methods_helpers import get
 
 
@@ -14,9 +15,6 @@ def test_202_status_code(session):
     get("/202", expected_status_code=202)
 
 
-def test_sync_500_internal_server_error(session):
-    get("/sync/raise", expected_status_code=500)
-
-
-def test_async_500_internal_server_error(session):
-    get("/async/raise", expected_status_code=500)
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_sync_500_internal_server_error(function_type: str, session):
+    get(f"/{function_type}/raise", expected_status_code=500)

--- a/integration_tests/test_status_code.py
+++ b/integration_tests/test_status_code.py
@@ -1,4 +1,4 @@
-from utils import get
+from http_methods_helpers import get
 
 
 def test_404_status_code(session):

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -1,0 +1,68 @@
+from typing import Optional
+import requests
+
+
+BASE_URL = "http://127.0.0.1:8080"
+
+
+def check_response(response: requests.Response, expected_status_code: int):
+    assert response.status_code == expected_status_code
+    assert "server" in response.headers
+    assert response.headers["server"] == "robyn"
+
+
+def get(
+    endpoint: str, expected_status_code: int = 200, headers: dict = {}
+) -> requests.Response:
+    endpoint = endpoint.strip("/")
+    response = requests.get(f"{BASE_URL}/{endpoint}", headers=headers)
+    check_response(response, expected_status_code)
+    return response
+
+
+def post(
+    endpoint: str,
+    data: Optional[dict] = None,
+    expected_status_code: int = 200,
+    headers: dict = {},
+) -> requests.Response:
+    endpoint = endpoint.strip("/")
+    response = requests.post(f"{BASE_URL}/{endpoint}", data=data, headers=headers)
+    check_response(response, expected_status_code)
+    return response
+
+
+def put(
+    endpoint: str,
+    data: Optional[dict] = None,
+    expected_status_code: int = 200,
+    headers: dict = {},
+) -> requests.Response:
+    endpoint = endpoint.strip("/")
+    response = requests.put(f"{BASE_URL}/{endpoint}", data=data, headers=headers)
+    check_response(response, expected_status_code)
+    return response
+
+
+def patch(
+    endpoint: str,
+    data: Optional[dict] = None,
+    expected_status_code: int = 200,
+    headers: dict = {},
+) -> requests.Response:
+    endpoint = endpoint.strip("/")
+    response = requests.patch(f"{BASE_URL}/{endpoint}", data=data, headers=headers)
+    check_response(response, expected_status_code)
+    return response
+
+
+def delete(
+    endpoint: str,
+    data: Optional[dict] = None,
+    expected_status_code: int = 200,
+    headers: dict = {},
+) -> requests.Response:
+    endpoint = endpoint.strip("/")
+    response = requests.delete(f"{BASE_URL}/{endpoint}", data=data, headers=headers)
+    check_response(response, expected_status_code)
+    return response

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -60,7 +60,7 @@ class Robyn:
 
     def before_request(self, endpoint: str) -> Callable[..., None]:
         """
-        The @app.before_request decorator to add a get route
+        You can use the @app.before_request decorator to call a method before routing to the specified endpoint
 
         :param endpoint str: endpoint to server the route
         """
@@ -69,7 +69,7 @@ class Robyn:
 
     def after_request(self, endpoint: str) -> Callable[..., None]:
         """
-        The @app.after_request decorator to add a get route
+        You can use the @app.after_request decorator to call a method after routing to the specified endpoint
 
         :param endpoint str: endpoint to server the route
         """
@@ -197,7 +197,7 @@ class Robyn:
 
     def get(self, endpoint: str, const: bool = False):
         """
-        The @app.get decorator to add a get route
+        The @app.get decorator to add a route with the GET method
 
         :param endpoint str: endpoint to server the route
         """
@@ -209,7 +209,7 @@ class Robyn:
 
     def post(self, endpoint: str):
         """
-        The @app.post decorator to add a get route
+        The @app.post decorator to add a route with POST method
 
         :param endpoint str: endpoint to server the route
         """
@@ -221,7 +221,7 @@ class Robyn:
 
     def put(self, endpoint: str):
         """
-        The @app.put decorator to add a get route
+        The @app.put decorator to add a get route with PUT method
 
         :param endpoint str: endpoint to server the route
         """
@@ -233,7 +233,7 @@ class Robyn:
 
     def delete(self, endpoint: str):
         """
-        The @app.delete decorator to add a get route
+        The @app.delete decorator to add a route with DELETE method
 
         :param endpoint str: endpoint to server the route
         """
@@ -245,7 +245,7 @@ class Robyn:
 
     def patch(self, endpoint: str):
         """
-        [The @app.patch decorator to add a get route]
+        The @app.patch decorator to add a route with PATCH method
 
         :param endpoint [str]: [endpoint to server the route]
         """
@@ -257,7 +257,7 @@ class Robyn:
 
     def head(self, endpoint: str):
         """
-        The @app.head decorator to add a get route
+        The @app.head decorator to add a route with HEAD method
 
         :param endpoint str: endpoint to server the route
         """
@@ -269,7 +269,7 @@ class Robyn:
 
     def options(self, endpoint: str):
         """
-        The @app.options decorator to add a get route
+        The @app.options decorator to add a route with OPTIONS method
 
         :param endpoint str: endpoint to server the route
         """
@@ -281,7 +281,7 @@ class Robyn:
 
     def connect(self, endpoint: str):
         """
-        The @app.connect decorator to add a get route
+        The @app.connect decorator to add a route with CONNECT method
 
         :param endpoint str: endpoint to server the route
         """
@@ -293,7 +293,7 @@ class Robyn:
 
     def trace(self, endpoint: str):
         """
-        The @app.trace decorator to add a get route
+        The @app.trace decorator to add a route with TRACE method
 
         :param endpoint str: endpoint to server the route
         """

--- a/robyn/argument_parser.py
+++ b/robyn/argument_parser.py
@@ -35,7 +35,7 @@ class ArgumentParser(argparse.ArgumentParser):
             help="Set the log level name",
         )
 
-        self.args = self.parser.parse_args()
+        self.args, unknown = self.parser.parse_known_args()
 
     @property
     def num_processes(self) -> int:

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -11,7 +11,7 @@ class SocketHeld:
 
 @dataclass
 class FunctionInfo:
-    function: Callable
+    handler: Callable
     is_async: bool
     number_of_params: int
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,8 +11,11 @@ use crate::io_helpers::read_file;
 #[pyclass]
 #[derive(Debug, Clone)]
 pub struct FunctionInfo {
+    #[pyo3(get, set)]
     pub handler: Py<PyAny>,
+    #[pyo3(get, set)]
     pub is_async: bool,
+    #[pyo3(get, set)]
     pub number_of_params: u8,
 }
 


### PR DESCRIPTION
**Description**

I felt like the tests needed to be better organized, so it would be easier to write new tests and to check the unit test coverage. This PR does the following to achieve those goals:
- Add a `utils.py` file that helps with requesting endpoints, and checks the status code and global headers of the response.
- Test everything with sync and async endpoints
- Add tests for adding a global header, startup handler and shutdown handler, and a test for modifying request headers with middlewares (which is skipped for now as this is currently bugged in Robyn)
- Rename endpoints for a better understanding (sync endpoints start with `/sync` and async one with `/async` for example)
- Fix some docstrings

There is still room for improvements, like actually testing if the startup and shutdown handlers are executed, but I didn't figure out a way to test this properly for now.