### PR TITLE
ci: build artifacts on every push and pull

### DIFF
--- a/.github/workflows/preview-deployments.yml
+++ b/.github/workflows/preview-deployments.yml
@@ -13,14 +13,11 @@ on:
 jobs:
   macos:
     runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.7"
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -32,11 +29,7 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           target: x86_64
-          args: -i python --release --out dist
-      - name: Install build wheel - x86_64
-        run: |
-          pip install --force-reinstall dist/robyn*.whl
-          cd ~ && python -c 'import robyn'
+          args: -i python --release --out dist --no-sdist
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
@@ -51,13 +44,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
         target: [x64, x86]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.7"
           architecture: ${{ matrix.target }}
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -69,7 +61,7 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: -i python --release --out dist --no-sdist
+          args: -i python3.7 --release --out dist --no-sdist
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
@@ -80,7 +72,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
         target: [x86_64, i686]
     steps:
       - uses: actions/checkout@v3
@@ -92,13 +83,13 @@ jobs:
           default: true
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.7"
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           manylinux: auto
-          args: -i python${{ matrix.python-version }} --release --out dist --no-sdist
+          args: -i python3.7 --out dist --no-sdist
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
@@ -109,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [{ version: "3.7", abi: "cp37-cp37m" }]
+        python: [{ abi: "cp37-cp37m" }]
         target: [aarch64, armv7, s390x, ppc64le]
     steps:
       - uses: actions/checkout@v3
@@ -120,7 +111,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: auto
-          args: -i python3.9 --release --out dist --no-sdist
+          args: -i python3.7 --release --out dist --no-sdist
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/preview-deployments.yml
+++ b/.github/workflows/preview-deployments.yml
@@ -1,0 +1,128 @@
+# CI to release the project for Linux, Windows, and MacOS
+
+name: Upload Preview Packages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.7"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+          profile: minimal
+          default: true
+      - name: Build wheels - x86_64
+        uses: messense/maturin-action@v1
+        with:
+          target: x86_64
+          args: -i python --release --out dist
+      - name: Install build wheel - x86_64
+        run: |
+          pip install --force-reinstall dist/robyn*.whl
+          cd ~ && python -c 'import robyn'
+      - name: Build wheels - universal2
+        uses: messense/maturin-action@v1
+        with:
+          args: -i python --release --universal2 --out dist --no-sdist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.7"]
+        target: [x64, x86]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          default: true
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: -i python --release --out dist --no-sdist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7"]
+        target: [x86_64, i686]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          default: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build Wheels
+        uses: messense/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          args: -i python${{ matrix.python-version }} --release --out dist --no-sdist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+  linux-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [{ version: "3.7", abi: "cp37-cp37m" }]
+        target: [aarch64, armv7, s390x, ppc64le]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Wheels
+        uses: messense/maturin-action@v1
+        env:
+          PYO3_CROSS_LIB_DIR: /opt/python/${{ matrix.python.abi }}/lib
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          args: -i python3.9 --release --out dist --no-sdist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist


### PR DESCRIPTION
**Description**

Changing this as I want to build an artifact on every PR. That way it will be easier for us to just download the artifact and test it on our PC.

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->
