### PR TITLE
chore(ci): fix robyn installation in test CI

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -24,12 +24,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r robyn/test-requirements.txt
       - name: Add macos target
-        if: ${{ matrix.os }} == macos
+        if: matrix.os == 'macos'
         run: rustup target add aarch64-apple-darwin
       - name: Setup Rust part of the project
         run: |
           maturin build -i python --universal2 --out dist --no-sdist
-          pip install --force-reinstall --find-links=.dist/ robyn
+          pip install --no-index --find-links=dist/ robyn
       - name: Test with pytest
         run: |
           pytest ./integration_tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "maturin"
 [project]
 name = "robyn"
 dependencies = [
-  'watchdog == 2.1.3',
+  'watchdog == 2.2.1',
   'multiprocess == 0.70.12.2',
 # conditional
   'uvloop == 0.17.0; sys_platform == "darwin"',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests==2.26.0
 pytest==6.2.5
 maturin
 uvloop; platform_system!="Windows"
-watchdog
+watchdog==2.2.1
 multiprocess==0.70.12.2

--- a/robyn/test-requirements.txt
+++ b/robyn/test-requirements.txt
@@ -1,6 +1,6 @@
 pytest==6.2.5
 maturin==0.12.11
-watchdog
+watchdog==2.2.1
 requests==2.26.0
 uvloop==0.17.0; platform_system!="Windows"
 multiprocess==0.70.12.2


### PR DESCRIPTION
**Description**

I noticed with my latest PRs that the CI had some issues after my updates... It was downloading the `robyn` package from Pypi instead of installing it from the `whl` built locally. Also the if condition for installing the macos rust target wasn't working.
This fixes all those issues! (had to fix the `watchdog` version for this as we want to have the same version installed with the requirements and required by `robyn`)