### PR TITLE
fix: fix terminal hijacking in windows

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 use std::sync::{Arc, RwLock};
 
+use std::process::abort;
 use std::thread;
 
 use actix_files::Files;
@@ -201,7 +202,8 @@ impl Server {
                         .unwrap();
                     Ok(())
                 })
-            })?
+            })?;
+            abort();
         }
         Ok(())
     }


### PR DESCRIPTION
**Description**
Ctrl + C should work on windows now

This PR fixes #373 

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->
