### PR TITLE
chore(ci): fix rust ci warnings

### DIFF
--- a/.github/workflows/preview-deployments.yml
+++ b/.github/workflows/preview-deployments.yml
@@ -18,20 +18,16 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: aarch64-apple-darwin
-          profile: minimal
-          default: true
+          targets: aarch64-apple-darwin
       - name: Build wheels - x86_64
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         with:
           target: x86_64
           args: -i python --release --out dist --no-sdist
       - name: Build wheels - universal2
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         with:
           args: -i python --release --universal2 --out dist --no-sdist
       - name: Upload wheels
@@ -51,14 +47,9 @@ jobs:
         with:
           python-version: "3.7"
           architecture: ${{ matrix.target }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build wheels
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           args: -i python3.7 --release --out dist --no-sdist
@@ -75,17 +66,12 @@ jobs:
         target: [x86_64, i686]
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Build Wheels
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           manylinux: auto
@@ -105,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build Wheels
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         env:
           PYO3_CROSS_LIB_DIR: /opt/python/${{ matrix.python.abi }}/lib
         with:

--- a/.github/workflows/release-CI.yml
+++ b/.github/workflows/release-CI.yml
@@ -18,15 +18,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: aarch64-apple-darwin
-          profile: minimal
-          default: true
+          targets: aarch64-apple-darwin
       - name: Build wheels - x86_64
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         with:
           target: x86_64
           args: -i python --release --out dist
@@ -35,7 +31,7 @@ jobs:
           pip install --force-reinstall dist/robyn*.whl
           cd ~ && python -c 'import robyn'
       - name: Build wheels - universal2
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         with:
           args: -i python --release --universal2 --out dist
       - name: Install build wheel - universal2
@@ -60,14 +56,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.target }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build wheels
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           args: -i python --release --out dist
@@ -90,17 +81,12 @@ jobs:
         target: [x86_64, i686]
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build Wheels
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           manylinux: auto
@@ -132,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build Wheels
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         env:
           PYO3_CROSS_LIB_DIR: /opt/python/${{ matrix.python.abi }}/lib
         with:

--- a/.github/workflows/rust-CI.yml
+++ b/.github/workflows/rust-CI.yml
@@ -9,58 +9,34 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+      - run: cargo fmt --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+          components: clippy
+      - run: cargo clippy -- -D warnings

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,22 +1,22 @@
-use core::{mem};
+use core::mem;
+use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::{
     convert::Infallible,
-    task::{Context, Poll},
     pin::Pin,
+    task::{Context, Poll},
 };
-use std::collections::HashMap;
 
+use actix_http::body::BodySize;
+use actix_http::body::MessageBody;
 use actix_web::web::Bytes;
 use actix_web::{http::Method, HttpRequest};
-use actix_http::body::MessageBody;
-use actix_http::body::BodySize;
 
 use anyhow::Result;
 use dashmap::DashMap;
-use pyo3::{exceptions, prelude::*};
-use pyo3::types::{PyBytes, PyString};
 use pyo3::exceptions::PyValueError;
+use pyo3::types::{PyBytes, PyString};
+use pyo3::{exceptions, prelude::*};
 
 use crate::io_helpers::read_file;
 
@@ -36,9 +36,10 @@ impl ActixBytesWrapper {
         } else if let Ok(v) = raw_body.downcast::<PyBytes>() {
             v.as_bytes().to_vec()
         } else {
-            return Err(PyValueError::new_err(
-                format!("Could not convert {} specified body to bytes", type_of(raw_body))
-            ));
+            return Err(PyValueError::new_err(format!(
+                "Could not convert {} specified body to bytes",
+                type_of(raw_body)
+            )));
         };
         Ok(Self(Bytes::from(value)))
     }


### PR DESCRIPTION
**Description**

Replace the unmaintained actions-rs/toolchain CI with the up to date dtolnay/rust-toolchain CI.
This gets rid of some warnings we had in the CI. Also, the `set-output` command used in the action-rs/toolchain CI is deprecated and will drop support in June of this year (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).