### PR TITLE
feat: Allow global level Response headers

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -171,7 +171,7 @@ async def hello(request):
     return "Hello World"
 ```
 
-## Global Headers
+## Global Request Headers
 
 You can also add global headers for every request.
 
@@ -179,9 +179,17 @@ You can also add global headers for every request.
 app.add_request_header("server", "robyn")
 ```
 
+## Global Response Headers
+
+You can also add global response headers for every request.
+
+```python
+app.add_response_header("content-type", "application/json")
+```
+
 ## Per route headers
 
-You can also add headers for every route.
+You can also add request and response headers for every route.
 
 ```python
 @app.get("/request_headers")
@@ -190,6 +198,14 @@ async def request_headers():
         "status_code": 200,
         "body": "",
         "type": "text",
+        "headers": {"Header": "header_value"},
+    }
+```
+
+```python
+@app.get("/response_headers")
+async def response_headers():
+    return {
         "headers": {"Header": "header_value"},
     }
 ```

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -511,7 +511,7 @@ def async_decorator_view():
 
 
 if __name__ == "__main__":
-    app.add_request_header("server", "robyn")
+    app.add_response_header("server", "robyn")
     app.add_directory(
         route="/test_dir",
         directory_path=os.path.join(current_file_path, "build"),

--- a/integration_tests/test_app.py
+++ b/integration_tests/test_app.py
@@ -9,6 +9,12 @@ def test_add_request_header():
     assert app.request_headers == [Header(key="server", val="robyn")]
 
 
+def test_add_response_header():
+    app = Robyn(__file__)
+    app.add_response_header("content-type", "application/json")
+    assert app.response_headers == [Header(key="content-type", val="application/json")]
+
+
 def test_lifecycle_handlers():
     def mock_startup_handler():
         pass

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -33,6 +33,7 @@ class Robyn:
         self.middleware_router = MiddlewareRouter()
         self.web_socket_router = WebSocketRouter()
         self.request_headers: List[Header] = []  # This needs a better type
+        self.response_headers: List[Header] = []  # This needs a better type
         self.directories: List[Directory] = []
         self.event_handlers = {}
         load_vars(project_root=directory_path)
@@ -83,6 +84,9 @@ class Robyn:
     def add_request_header(self, key: str, value: str) -> None:
         self.request_headers.append(Header(key, value))
 
+    def add_response_header(self, key: str, value: str) -> None:
+        self.response_headers.append(Header(key, value))
+
     def add_web_socket(self, endpoint: str, ws: WS) -> None:
         self.web_socket_router.add_route(endpoint, ws)
 
@@ -126,6 +130,7 @@ class Robyn:
                 self.event_handlers,
                 self.config.workers,
                 self.config.processes,
+                self.response_headers,
             )
         else:
             event_handler = EventHandler(
@@ -139,6 +144,7 @@ class Robyn:
                 self.event_handlers,
                 self.config.workers,
                 self.config.processes,
+                self.response_headers,
             )
             event_handler.start_server()
             logger.info(

--- a/robyn/dev_event_handler.py
+++ b/robyn/dev_event_handler.py
@@ -23,11 +23,13 @@ class EventHandler(FileSystemEventHandler):
         event_handlers: Dict[Events, FunctionInfo],
         workers: int,
         processes: int,
+        response_headers: List[Header],
     ) -> None:
         self.url = url
         self.port = port
         self.directories = directories
         self.request_headers = request_headers
+        self.response_headers = response_headers
         self.routes = routes
         self.middlewares = middlewares
         self.web_sockets = web_sockets
@@ -48,6 +50,7 @@ class EventHandler(FileSystemEventHandler):
             self.event_handlers,
             self.n_workers,
             self.n_processes,
+            self.response_headers,
             True,
         )
 

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -23,6 +23,7 @@ def run_processes(
     event_handlers: Dict[Events, FunctionInfo],
     workers: int,
     processes: int,
+    response_headers: List[Header],
     from_event_handler: bool = False,
 ) -> List[Process]:
     socket = SocketHeld(url, port)
@@ -37,6 +38,7 @@ def run_processes(
         socket,
         workers,
         processes,
+        response_headers,
     )
 
     if not from_event_handler:
@@ -66,6 +68,7 @@ def init_processpool(
     socket: SocketHeld,
     workers: int,
     processes: int,
+    response_headers: List[Header],
 ) -> List[Process]:
     process_pool = []
     if sys.platform.startswith("win32"):
@@ -78,6 +81,7 @@ def init_processpool(
             event_handlers,
             socket,
             workers,
+            response_headers,
         )
 
         return process_pool
@@ -95,6 +99,7 @@ def init_processpool(
                 event_handlers,
                 copied_socket,
                 workers,
+                response_headers,
             ),
         )
         process.start()
@@ -128,6 +133,7 @@ def spawn_process(
     event_handlers: Dict[Events, FunctionInfo],
     socket: SocketHeld,
     workers: int,
+    response_headers: List[Header],
 ):
     """
     This function is called by the main process handler to create a server runtime.
@@ -155,6 +161,9 @@ def spawn_process(
 
     for header in request_headers:
         server.add_request_header(*header.as_list())
+
+    for header in response_headers:
+        server.add_response_header(*header.as_list())
 
     for route in routes:
         route_type, endpoint, function, is_const = route

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -37,6 +37,8 @@ class Server:
         pass
     def add_request_header(self, key: str, value: str) -> None:
         pass
+    def add_response_header(self, key: str, value: str) -> None:
+        pass
     def add_route(
         self,
         route_type: str,

--- a/src/types.rs
+++ b/src/types.rs
@@ -164,6 +164,7 @@ pub struct Response {
 
 #[pymethods]
 impl Response {
+    // To do: Add check for content-type in header and change response_type accordingly
     #[new]
     pub fn new(status_code: u16, headers: HashMap<String, String>, body: &PyAny) -> PyResult<Self> {
         Ok(Self {


### PR DESCRIPTION
**Description**

This PR fixes #335 

- Add support for global level response headers
- @sansyrox  We can merge `add_response_header` & `add_request_header` and `remove_header` & `remove_response_header`?

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->
