### PR TITLE
better way to compare type

### DIFF
--- a/robyn/router.py
+++ b/robyn/router.py
@@ -25,7 +25,7 @@ class Router(BaseRouter):
 
     def _format_response(self, res):
         response = {}
-        if type(res) == dict:
+        if isinstance(res, dict):
             status_code = res.get("status_code", 200)
             headers = res.get("headers", {"Content-Type": "text/plain"})
             body = res.get("body", "")
@@ -37,9 +37,9 @@ class Router(BaseRouter):
             file_path = res.get("file_path")
             if file_path is not None:
                 response.set_file_path(file_path)
-        elif type(res) == Response:
+        elif isinstance(res, Response):
             response = res
-        elif type(res) == bytes:
+        elif isinstance(res, bytes):
             response = Response(
                 status_code=200,
                 headers={"Content-Type": "application/octet-stream"},


### PR DESCRIPTION
Instead of checking type of variable using type method, we can use `isinstance` method to check.

This PR fixes #

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->
