### PR TITLE
fix: Implement auto installation of uvloop on linux arm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ dependencies = [
   'nestd==0.3.1',
 # conditional
   'uvloop == 0.17.0; sys_platform != "win32"',
-  'uvloop == 0.17.0; platform_machine == "x86_64"',
-  'uvloop == 0.17.0; platform_machine == "i686"'
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   'multiprocess == 0.70.14',
   'nestd==0.3.1',
 # conditional
-  'uvloop == 0.17.0; sys_platform == "darwin"',
+  'uvloop == 0.17.0; sys_platform != "win32"',
   'uvloop == 0.17.0; platform_machine == "x86_64"',
   'uvloop == 0.17.0; platform_machine == "i686"'
 ]


### PR DESCRIPTION
**Description**

This PR fixes #395

fix: Implement auto installation of uvloop on linux arm
<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->
