### PR TITLE
Rename params with path_params

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.257
+    rev: v0.0.259
     hooks:
       - id: ruff
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robyn"
-version = "0.26.000001"
+version = "0.26.0"
 authors = ["Sanskar Jethi <sansyrox@gmail.com>"]
 edition = "2018"
 description = "A web server that is fast!"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robyn"
-version = "0.26.0"
+version = "0.26.000001"
 authors = ["Sanskar Jethi <sansyrox@gmail.com>"]
 edition = "2018"
 description = "A web server that is fast!"

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -255,8 +255,8 @@ async def async_json_const_get():
 
 
 @app.get("/sync/param/:id")
-def sync_param(Request):
-    id = Request.path_params["id"]
+def sync_param(request: Request):
+    id = request.path_params["id"]
     return id
 
 

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -4,6 +4,7 @@ import pathlib
 from robyn import WS, Robyn, Request, Response, jsonify, serve_file, serve_html
 from robyn.templating import JinjaTemplate
 
+
 from views import SyncView, AsyncView
 
 app = Robyn(__file__)
@@ -254,26 +255,26 @@ async def async_json_const_get():
 
 
 @app.get("/sync/param/:id")
-def sync_param(request: Request):
-    id = request.params["id"]
+def sync_param(Request):
+    id = Request.path_params["id"]
     return id
 
 
 @app.get("/async/param/:id")
 async def async_param(request: Request):
-    id = request.params["id"]
+    id = request.path_params["id"]
     return id
 
 
 @app.get("/sync/extra/*extra")
 def sync_param_extra(request: Request):
-    extra = request.params["extra"]
+    extra = request.path_params["extra"]
     return extra
 
 
 @app.get("/async/extra/*extra")
 async def async_param_extra(request: Request):
-    extra = request.params["extra"]
+    extra = request.path_params["extra"]
     return extra
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ name = "robyn"
 dependencies = [
   'watchdog == 2.2.1',
   'multiprocess == 0.70.14',
-  'psutil == 5.9.4',
   'nestd == 0.3.1',
 # conditional
   'uvloop == 0.17.0; sys_platform == "darwin"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 name = "robyn"
-version = "0.26.0"
+version = "0.26.000001"
 description = "A web server that is fast!"
 authors = ["Sanskar Jethi <sansyrox@gmail.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 name = "robyn"
-version = "0.26.000001"
+version = "0.26.0"
 description = "A web server that is fast!"
 authors = ["Sanskar Jethi <sansyrox@gmail.com>"]
 

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -25,7 +25,7 @@ class Url:
 class Request:
     queries: dict[str, str]
     headers: dict[str, str]
-    params: dict[str, str]
+    path_params: dict[str, str]
     body: Union[str, bytes]
     method: str
     url: Url

--- a/src/server.rs
+++ b/src/server.rs
@@ -158,7 +158,12 @@ impl Server {
                         app = app.route(
                             &route.clone(),
                             web::get().to(move |stream: web::Payload, req: HttpRequest| {
-                                start_web_socket(req, stream, path_params.clone(), task_locals.clone())
+                                start_web_socket(
+                                    req,
+                                    stream,
+                                    path_params.clone(),
+                                    task_locals.clone(),
+                                )
                             }),
                         );
                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -153,12 +153,12 @@ impl Server {
                     let web_socket_map = web_socket_router.get_web_socket_map();
                     for (elem, value) in (web_socket_map.read().unwrap()).iter() {
                         let route = elem.clone();
-                        let params = value.clone();
+                        let path_params = value.clone();
                         let task_locals = task_locals.clone();
                         app = app.route(
                             &route.clone(),
                             web::get().to(move |stream: web::Payload, req: HttpRequest| {
-                                start_web_socket(req, stream, params.clone(), task_locals.clone())
+                                start_web_socket(req, stream, path_params.clone(), task_locals.clone())
                             }),
                         );
                     }
@@ -347,7 +347,7 @@ async fn index(
     // Before middleware
     request = match middleware_router.get_route(&MiddlewareRoute::BeforeRequest, req.uri().path()) {
         Some((function, route_params)) => {
-            request.params = route_params;
+            request.path_params = route_params;
             execute_middleware_function(&request, function)
                 .await
                 .unwrap_or_else(|e| {
@@ -363,7 +363,7 @@ async fn index(
         res
     } else if let Some((function, route_params)) = router.get_route(req.method(), req.uri().path())
     {
-        request.params = route_params;
+        request.path_params = route_params;
         execute_http_function(&request, function)
             .await
             .unwrap_or_else(|e| {
@@ -383,7 +383,7 @@ async fn index(
     // After middleware
     response = match middleware_router.get_route(&MiddlewareRoute::AfterRequest, req.uri().path()) {
         Some((function, route_params)) => {
-            request.params = route_params;
+            request.path_params = route_params;
             execute_middleware_function(&response, function)
                 .await
                 .unwrap_or_else(|e| {

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -10,7 +10,7 @@ pub struct Request {
     pub queries: HashMap<String, String>,
     pub headers: HashMap<String, String>,
     pub method: String,
-    pub params: HashMap<String, String>,
+    pub path_params: HashMap<String, String>,
     #[pyo3(from_py_with = "get_body_from_pyobject")]
     pub body: Vec<u8>,
     pub url: Url,
@@ -20,11 +20,11 @@ impl ToPyObject for Request {
     fn to_object(&self, py: Python) -> PyObject {
         let queries = self.queries.clone().into_py(py).extract(py).unwrap();
         let headers = self.headers.clone().into_py(py).extract(py).unwrap();
-        let params = self.params.clone().into_py(py).extract(py).unwrap();
+        let path_params = self.path_params.clone().into_py(py).extract(py).unwrap();
         let body = String::from_utf8(self.body.to_vec()).unwrap().to_object(py);
         let request = PyRequest {
             queries,
-            params,
+            path_params,
             headers,
             body,
             method: self.method.clone(),
@@ -44,8 +44,8 @@ impl Request {
         if !req.query_string().is_empty() {
             let split = req.query_string().split('&');
             for s in split {
-                let params = s.split_once('=').unwrap_or((s, ""));
-                queries.insert(params.0.to_string(), params.1.to_string());
+                let path_params = s.split_once('=').unwrap_or((s, ""));
+                queries.insert(path_params.0.to_string(), path_params.1.to_string());
             }
         }
         let headers = req
@@ -69,7 +69,7 @@ impl Request {
             queries,
             headers,
             method: req.method().as_str().to_owned(),
-            params: HashMap::new(),
+            path_params: HashMap::new(),
             body: body.to_vec(),
             url,
         }
@@ -84,7 +84,7 @@ pub struct PyRequest {
     #[pyo3(get, set)]
     pub headers: Py<PyDict>,
     #[pyo3(get, set)]
-    pub params: Py<PyDict>,
+    pub path_params: Py<PyDict>,
     #[pyo3(get)]
     pub body: Py<PyAny>,
     #[pyo3(get)]


### PR DESCRIPTION
**Description**
This pull request address the proposal to rename `params` with `path_params`.

This PR fixes #457 

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Creating a test deployment:

You need to change the version number by appending the last digit for a test-pypi deployment.

e.g. if the current version of Robyn is `v0.18.1` the test deployment should be `v0.18.100001` (five zeroes as there are five characters in Robyn) and then an incremental digit.

Change the version number in `pyproject.yaml` and `Cargo.toml` to trigger a test deploy.
-->
