### PR TITLE
✨ feat: display Robyn version on start app

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -12,11 +12,14 @@ from robyn.events import Events
 from robyn.logger import logger
 from robyn.processpool import run_processes
 from robyn.responses import jsonify, serve_file, serve_html
-from robyn.robyn import FunctionInfo, Request, Response
+from robyn.robyn import FunctionInfo, Request, Response, get_version
 from robyn.router import MiddlewareRouter, Router, WebSocketRouter
 from robyn.types import Directory, Header
 from robyn.status_codes import StatusCodes
 from robyn.ws import WS
+
+
+__version__ = get_version()
 
 
 class Robyn:
@@ -120,6 +123,7 @@ class Robyn:
         url = os.getenv("ROBYN_URL", url)
         port = int(os.getenv("ROBYN_PORT", port))
 
+        logger.info(f"Robyn version: {__version__}")
         logger.info(f"Starting server at {url}:{port}")
 
         mp.allow_connection_pickling()

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -3,6 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Optional, Union
 
+def get_version() -> str:
+    pass
+
 class SocketHeld:
     def __init__(self, url: str, port: int):
         pass

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,15 @@ use shared_socket::SocketHeld;
 use pyo3::prelude::*;
 use types::{function_info::FunctionInfo, request::PyRequest, response::PyResponse};
 
+#[pyfunction]
+fn get_version() -> String {
+    env!("CARGO_PKG_VERSION").into()
+}
+
 #[pymodule]
 pub fn robyn(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    // the pymodule class to make the rustPyFunctions available
+    // the pymodule class/function to make the rustPyFunctions available
+    m.add_function(wrap_pyfunction!(get_version, m)?)?;
     m.add_class::<Server>()?;
     m.add_class::<SocketHeld>()?;
     m.add_class::<FunctionInfo>()?;


### PR DESCRIPTION
Display Robyn version on start apps:
```sh
(venv) user@pc robyn % python integration_tests/base_routes.py
INFO:robyn.logger:Robyn version: 0.28.3
INFO:robyn.logger:Starting server at 127.0.0.1:8080
INFO:robyn.logger:Press Ctrl + C to stop 

Starting up
INFO:actix_server.builder:Starting 1 workers
INFO:actix_server.server:Actix runtime found; starting in Actix runtime
```
