### PR TITLE
feat: add --open flag to open browser on successful start of the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,16 @@ options:
   --workers WORKERS         Choose the number of workers. [Default: 1]
   --dev                     Development mode. It restarts the server based on file changes.
   --log-level LOG_LEVEL     Set the log level name
+  --create                  Create a new project template.
+  --docs                    Open the Robyn documentation.
+  --open-browser            Open the browser on successful start.
 ```
 Log level can be `DEBUG`, `INFO`, `WARNING`, or `ERROR`.
+    
+When running the app using `--open-browser` a new browser window will open at the app location, e.g:
+```
+$ python3 app.py --open-browser
+```
 
 ### 💻 Add more routes
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -137,6 +137,7 @@ class Robyn:
 
         url = os.getenv("ROBYN_URL", url)
         port = int(os.getenv("ROBYN_PORT", port))
+        open_browser = bool(os.getenv("ROBYN_BROWSER_OPEN", self.config.open_browser))
 
         logger.info(f"Robyn version: {__version__}")
         logger.info(f"Starting server at {url}:{port}")
@@ -156,7 +157,7 @@ class Robyn:
             self.config.workers,
             self.config.processes,
             self.response_headers,
-            self.config.open_browser,
+            open_browser,
         )
 
     def exception(self, exception_handler: Callable):

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -153,6 +153,7 @@ class Robyn:
             self.config.workers,
             self.config.processes,
             self.response_headers,
+            self.config.open_browser,
         )
 
     def add_view(self, endpoint: str, view: Callable, const: bool = False):

--- a/robyn/argument_parser.py
+++ b/robyn/argument_parser.py
@@ -45,6 +45,12 @@ class Config:
             default=False,
             help="Open the Robyn documentation.",
         )
+        parser.add_argument(
+            "--open",
+            action="store_true",
+            default=False,
+            help="Open the browser on successful start.",
+        )
 
         args, _ = parser.parse_known_args()
 
@@ -53,6 +59,7 @@ class Config:
         self.dev = args.dev
         self.create = args.create
         self.docs = args.docs
+        self.open_browser = args.open
 
         if self.dev and (self.processes != 1 or self.workers != 1):
             raise Exception("--processes and --workers shouldn't be used with --dev")

--- a/robyn/argument_parser.py
+++ b/robyn/argument_parser.py
@@ -46,7 +46,7 @@ class Config:
             help="Open the Robyn documentation.",
         )
         parser.add_argument(
-            "--open",
+            "--open-browser",
             action="store_true",
             default=False,
             help="Open the browser on successful start.",
@@ -59,7 +59,7 @@ class Config:
         self.dev = args.dev
         self.create = args.create
         self.docs = args.docs
-        self.open_browser = args.open
+        self.open_browser = args.open_browser
 
         if self.dev and (self.processes != 1 or self.workers != 1):
             raise Exception("--processes and --workers shouldn't be used with --dev")

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -1,4 +1,5 @@
 import asyncio
+import webbrowser
 from multiprocess import Process
 import signal
 import sys
@@ -25,6 +26,7 @@ def run_processes(
     workers: int,
     processes: int,
     response_headers: List[Header],
+    open_browser: bool,
 ) -> List[Process]:
     socket = SocketHeld(url, port)
 
@@ -49,6 +51,10 @@ def run_processes(
 
     signal.signal(signal.SIGINT, terminating_signal_handler)
     signal.signal(signal.SIGTERM, terminating_signal_handler)
+
+    if open_browser:
+        logger.info("Opening browser...")
+        webbrowser.open_new_tab(f"http://{url}:{port}/")
 
     logger.info("Press Ctrl + C to stop \n")
     for process in process_pool:


### PR DESCRIPTION
**Description**

This PR fixes #503 

This PR adds the optional `--open` flag to use as a startup argument, which, when added, will launch the browser with the URL and PORT upon the successful start of the server.

Example usage:
```
python integration_tests/base_routes.py  --open
```
Will open the browser:
![image](https://github.com/sansyrox/robyn/assets/41922392/037a594e-e700-47e3-b146-98fbfe0cfb9b)

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
