### PR TITLE
feat: add ip_addr field to Request object

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -48,6 +48,18 @@ app.start(port=8080)
 
 ```
 
+### Keep track of a client's IP address
+
+```python
+from robyn import Robyn
+
+app = Robyn(__file__)
+
+@app.get("/")
+async def h(request):
+    return f"hello to you, {request.ip_addr}"
+```
+
 ### Interaction with a Database
 
 It should be fairly easy to make a crud app example. Here's a minimal example using Prisma (`pip install prisma-client-py`) with Robyn.

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -99,6 +99,7 @@ def sync_after_request(response: Response):
 def sync_middlewares(request: Request):
     assert "before" in request.headers
     assert request.headers["before"] == "sync_before_request"
+    assert request.ip_addr == "127.0.0.1"
     return "sync middlewares"
 
 
@@ -119,6 +120,7 @@ async def async_after_request(response: Response):
 async def async_middlewares(request: Request):
     assert "before" in request.headers
     assert request.headers["before"] == "async_before_request"
+    assert request.ip_addr == "127.0.0.1"
     return "async middlewares"
 
 

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -60,7 +60,7 @@ class Request:
         params (dict[str, str]): The parameters of the request. e.g. /user/:id -> {"id": "123"}
         body (Union[str, bytes]): The body of the request. If the request is a JSON, it will be a dict.
         method (str): The method of the request. e.g. GET, POST, PUT, DELETE
-        ip_addr (str): The IP Address of the client
+        ip_addr (Optional[str]): The IP Address of the client
     """
 
     queries: dict[str, str]
@@ -69,7 +69,7 @@ class Request:
     body: Union[str, bytes]
     method: str
     url: Url
-    ip_addr: str
+    ip_addr: Optional[str]
 
 @dataclass
 class Response:

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -60,6 +60,7 @@ class Request:
         params (dict[str, str]): The parameters of the request. e.g. /user/:id -> {"id": "123"}
         body (Union[str, bytes]): The body of the request. If the request is a JSON, it will be a dict.
         method (str): The method of the request. e.g. GET, POST, PUT, DELETE
+        ip_addr (str): The IP Address of the client
     """
 
     queries: dict[str, str]
@@ -68,6 +69,7 @@ class Request:
     body: Union[str, bytes]
     method: str
     url: Url
+    ip_addr: str
 
 @dataclass
 class Response:

--- a/src/server.rs
+++ b/src/server.rs
@@ -380,6 +380,10 @@ async fn index(
     req: HttpRequest,
 ) -> impl Responder {
     let mut request = Request::from_actix_request(&req, body, &global_request_headers);
+    request.ip_addr = req
+        .peer_addr()
+        .map(|val| val.ip().to_string())
+        .unwrap_or_else(String::new);
 
     // Before middleware
     // Global

--- a/src/server.rs
+++ b/src/server.rs
@@ -380,10 +380,6 @@ async fn index(
     req: HttpRequest,
 ) -> impl Responder {
     let mut request = Request::from_actix_request(&req, body, &global_request_headers);
-    request.ip_addr = req
-        .peer_addr()
-        .map(|val| val.ip().to_string())
-        .unwrap_or_else(String::new);
 
     // Before middleware
     // Global

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -14,6 +14,7 @@ pub struct Request {
     #[pyo3(from_py_with = "get_body_from_pyobject")]
     pub body: Vec<u8>,
     pub url: Url,
+    pub ip_addr: String,
 }
 
 impl ToPyObject for Request {
@@ -33,6 +34,7 @@ impl ToPyObject for Request {
             body,
             method: self.method.clone(),
             url: self.url.clone(),
+            ip_addr: self.ip_addr.clone(),
         };
         Py::new(py, request).unwrap().as_ref(py).into()
     }
@@ -76,6 +78,7 @@ impl Request {
             path_params: HashMap::new(),
             body: body.to_vec(),
             url,
+            ip_addr: String::new(),
         }
     }
 }
@@ -95,6 +98,8 @@ pub struct PyRequest {
     pub method: String,
     #[pyo3(get)]
     pub url: Url,
+    #[pyo3(get)]
+    pub ip_addr: String,
 }
 
 #[pymethods]

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -70,10 +70,10 @@ impl Request {
             req.connection_info().host(),
             req.path(),
         );
-         let ip_addr = req
-             .peer_addr()
-             .map(|val| val.ip().to_string())
-             .unwrap_or_else(String::new);
+        let ip_addr = req
+            .peer_addr()
+            .map(|val| val.ip().to_string())
+            .unwrap_or_else(String::new);
 
         Self {
             queries,

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -14,7 +14,7 @@ pub struct Request {
     #[pyo3(from_py_with = "get_body_from_pyobject")]
     pub body: Vec<u8>,
     pub url: Url,
-    pub ip_addr: String,
+    pub ip_addr: Option<String>,
 }
 
 impl ToPyObject for Request {
@@ -70,10 +70,7 @@ impl Request {
             req.connection_info().host(),
             req.path(),
         );
-        let ip_addr = req
-            .peer_addr()
-            .map(|val| val.ip().to_string())
-            .unwrap_or_else(String::new);
+        let ip_addr = req.peer_addr().map(|val| val.ip().to_string());
 
         Self {
             queries,
@@ -103,7 +100,7 @@ pub struct PyRequest {
     #[pyo3(get)]
     pub url: Url,
     #[pyo3(get)]
-    pub ip_addr: String,
+    pub ip_addr: Option<String>,
 }
 
 #[pymethods]

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -70,6 +70,10 @@ impl Request {
             req.connection_info().host(),
             req.path(),
         );
+         let ip_addr = req
+             .peer_addr()
+             .map(|val| val.ip().to_string())
+             .unwrap_or_else(String::new);
 
         Self {
             queries,
@@ -78,7 +82,7 @@ impl Request {
             path_params: HashMap::new(),
             body: body.to_vec(),
             url,
-            ip_addr: String::new(),
+            ip_addr,
         }
     }
 }


### PR DESCRIPTION
**Description**

This PR contributes towards #524 by adding the client's IP address to the request object.
By having the client's IP address we can later on implement rate limiting per IP address.

An example assert was added to the middleware base routes.

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
