### PR TITLE
Don't respond with pong when a pong message is received.

### DIFF
--- a/src/web_socket_connection.rs
+++ b/src/web_socket_connection.rs
@@ -104,7 +104,6 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MyWs {
             }
             Ok(ws::Message::Pong(msg)) => {
                 debug!("Pong message {:?}", msg);
-                ctx.pong(&msg)
             }
             Ok(ws::Message::Text(_text)) => {
                 // need to also pass this text as a param


### PR DESCRIPTION
Makes the server aligned with the WS RFC.

From: https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#pings_and_pongs_the_heartbeat_of_websockets

See: "You might also get a pong without ever sending a ping; ignore this if it happens."

Fette & Melnikov             Standards Track                   [Page 37]
RFC 6455                 The WebSocket Protocol            December 2011

   A Pong frame MAY be sent unsolicited.  This serves as a
   unidirectional heartbeat.  A response to an unsolicited Pong frame is
   not expected.

Ref: https://datatracker.ietf.org/doc/rfc6455

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
