### PR TITLE
make returning text from websocket messages optional

### DIFF
--- a/src/web_socket_connection.rs
+++ b/src/web_socket_connection.rs
@@ -61,11 +61,13 @@ fn execute_ws_function(
         ctx.spawn(f);
     } else {
         Python::with_gil(|py| {
-             if let Some(op) = get_function_output(function, text, py, ws)
+            if let Some(op) = get_function_output(function, text, py, ws)
                 .unwrap()
-                .extract::<Option<&str>>().unwrap() {
-                 ctx.text(op);
-             }
+                .extract::<Option<&str>>()
+                .unwrap()
+            {
+                ctx.text(op);
+            }
         });
     }
 }

--- a/src/web_socket_connection.rs
+++ b/src/web_socket_connection.rs
@@ -61,11 +61,11 @@ fn execute_ws_function(
         ctx.spawn(f);
     } else {
         Python::with_gil(|py| {
-            let op: &str = get_function_output(function, text, py, ws)
+             if let Some(op) = get_function_output(function, text, py, ws)
                 .unwrap()
-                .extract()
-                .unwrap();
-            ctx.text(op);
+                .extract::<Option<&str>>().unwrap() {
+                 ctx.text(op);
+             }
         });
     }
 }


### PR DESCRIPTION
`websocket.on("message")` methods shouldn't be required to return a string value. This patch makes it optional to send a response.
The RFC does not mandate sending a text response when an application level data frame is received.