### PR TITLE
refactor: don't init config at class definition to allow custom config classes/argparser

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -55,28 +55,25 @@ def _normalize_endpoint(endpoint: str) -> str:
     return endpoint.rstrip("/")
 
 
-config = Config()
-
-if (compile_path := config.compile_rust_path) is not None:
-    compile_rust_files(compile_path)
-    print("Compiled rust files")
-
-
 class BaseRobyn(ABC):
     """This is the python wrapper for the Robyn binaries."""
 
     def __init__(
         self,
         file_object: str,
-        config: Config = Config(),
+        config: Optional[Config] = None,
         openapi_file_path: Optional[str] = None,
         openapi: Optional[OpenAPI] = None,
         dependencies: DependencyMap = DependencyMap(),
     ) -> None:
+        self.config = Config() if config is None else config
+        if (compile_path := self.config.compile_rust_path) is not None:
+            compile_rust_files(compile_path)
+            self.config.compile_rust_path = None
+
         directory_path = os.path.dirname(os.path.abspath(file_object))
         self.file_path = file_object
         self.directory_path = directory_path
-        self.config = config
         self.dependencies = dependencies
         self.openapi = openapi
 
@@ -640,7 +637,7 @@ class Robyn(BaseRobyn):
 
 
 class SubRouter(BaseRobyn):
-    def __init__(self, file_object: str, prefix: str = "", config: Config = Config(), openapi: OpenAPI = OpenAPI()) -> None:
+    def __init__(self, file_object: str, prefix: str = "", config: Optional[Config] = None, openapi: OpenAPI = OpenAPI()) -> None:
         super().__init__(file_object=file_object, config=config, openapi=openapi)
         self.prefix = prefix
 


### PR DESCRIPTION
## Description

This PR fixes #1246

## Summary

Python's default arguments are evaluated once when the function is defined. Config was instantiated at BaseRobyn class definition and __init__.py body. Call Config() only inside BaseRobyn, and if not None. At SubRouter, forward the config parameter.

For config.compile_rust_path, access from the class object, and unset to ensure compile_rust_path is called once per config object. Allows to write custom argument parsers without colliding with Config.parser.

This allows to pass implement alternative configs, for example:

```python
from robyn import Robyn, Response as RobynResponse
from robyn.argument_parser import Config as RobynConfig

from .handler import my_route

class AltConfig(RobynConfig):
    def __init__(self) -> None:
        self.disable_openapi = True
        self.dev = False
        self.log_level = "DEBUG"
        self.open_browser = False
        self.fast = 1
        self.workers = 1
        self.processes = 1
        self.compile_rust_path = None

config=AltConfig()
app = Robyn(__file__, config=config)

@app.post("/my-route")
async def route_my_route(request):
    response =  my_route(app.env,  request)
    return RobynResponse(
        status_code=response.status_code,
        headers=response.headers,
        description=response.body,
    )

def main():
    app.start(port=app.env.port)
```
## PR Checklist

Please ensure that:

- [X] The PR contains a descriptive title
- [X] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors how the `Config` class is initialized in Robyn to fix a bug (#1246) related to Python's default argument evaluation behavior. Instead of initializing the config at class definition and in `__init__.py`, it now initializes the config inside the `BaseRobyn` class only when needed. This change enables users to implement custom config classes and argument parsers without colliding with the default `Config.parser`. The PR also ensures that `compile_rust_path` is called only once per config object by unsetting it after use.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `robyn/__init__.py` |
</details>
