### PR TITLE
Add type hint for router in include_router method

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -522,21 +522,16 @@ class BaseRobyn(ABC):
 
     def include_router(self, router: "SubRouter"):
         """
-        Include routes from another router into this router.
+        The method to include the routes from another router.
 
-        Args:
-            router (SubRouter): Router instance whose routes will be mounted on
-                this router. The routes' path patterns and handlers are registered
-                on the current router.
+        Merge another SubRouter's routes, middlewares, websocket routes, and dependencies into this router.
+        Note: This operation mutates the current router's internal collections (route list, middleware lists,
+        websocket routes, and dependencies) and does not deep-copy the included router. Callers should ensure
+        there are no path or name conflicts before including a router.
 
-        Raises:
-            TypeError: If `router` is not an instance of SubRouter.
-
-        Example:
-            >>> app.include_router(other_router)
+        :param router Robyn: the router object to include the routes from
         """
         self.included_routers.append(router)
-
         self.router.routes.extend(router.router.routes)
         self.middleware_router.global_middlewares.extend(router.middleware_router.global_middlewares)
         self.middleware_router.route_middlewares.extend(router.middleware_router.route_middlewares)


### PR DESCRIPTION
This pull request introduces a type annotation for the `router` parameter in the `include_router` method within `robyn/__init__.py`. The change improves code clarity and type safety.

* Added a type annotation to the `router` parameter in the `include_router` method, specifying it as `"SubRouter"`.Add type hint for the 'router' parameter in include_router method.

## Description

This PR fixes #

## Summary

This PR does....

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [ ] The PR contains a descriptive title
- [ ] The PR contains a descriptive summary of the changes
- [ ] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a type hint to the `router` parameter in the `include_router` method, specifying it as `SubRouter`. This is a minor improvement that enhances type safety and code readability without changing any functionality.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `robyn/__init__.py` |
</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced router documentation with expanded details on merging behavior, including route and middleware handling, along with warnings about potential mutations and conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->