### PR TITLE
chore: Add `test_request_object_body_json` unit test

### DIFF
--- a/unit_tests/test_request_object.py
+++ b/unit_tests/test_request_object.py
@@ -1,4 +1,5 @@
 from robyn.robyn import Headers, QueryParams, Request, Url
+import pytest
 
 
 def test_request_object():
@@ -22,6 +23,42 @@ def test_request_object():
 
     assert request.url.scheme == "https"
     assert request.url.host == "localhost"
-    print(request.headers.get("Content-Type"))
     assert request.headers.get("Content-Type") == "application/json"
     assert request.method == "GET"
+
+
+def test_request_object_body_json():
+    url = Url(
+        scheme="https",
+        host="localhost",
+        path="/user",
+    )
+    request = Request(
+        query_params=QueryParams(),
+        headers=Headers({"Content-Type": "application/json"}),
+        path_params={},
+        body='{"key": "value"}',
+        method="POST",
+        url=url,
+        ip_addr=None,
+        identity=None,
+        form_data={},
+        files={},
+    )
+
+    assert request.json() == {"key": "value"}
+
+    request = Request(
+        query_params=QueryParams(),
+        headers=Headers({"Content-Type": "application/json"}),
+        path_params={},
+        body="",
+        method="POST",
+        url=url,
+        ip_addr=None,
+        identity=None,
+        form_data={},
+        files={},
+    )
+
+    pytest.raises(ValueError, request.json)


### PR DESCRIPTION
## Description

This PR is actually add small unit test for testing `Request` object

## Summary

In the `robyn/robyn.pyi`...

```python
@dataclass
class Request:
    # ...
    def json(self) -> dict:
        """
        If the body is a valid JSON this will return the parsed JSON data.
        Otherwise, this will throw a ValueError.
        """
        pass
```

But there are no unit tests to verify that a `ValueError` is raised when an invalid JSON body is provided.

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for request object JSON parsing: verifies valid JSON is parsed and an empty body raises a ValueError.
  * Removed a debug print in the test to keep test output clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->