### PR TITLE
fix: Fixes assert issue in websocket integration tests

### DIFF
--- a/integration_tests/test_web_sockets.py
+++ b/integration_tests/test_web_sockets.py
@@ -12,17 +12,18 @@ def test_web_socket_raw_benchmark(session):
     assert ws.recv() == "Hello world, from ws"
 
     ws.send("My name is?")
-    assert ws.recv() == "This is a broadcast message"
-    assert ws.recv() == "This is a message to self"
-    assert ws.recv() == "Whaaat??"
+    # Messages may arrive in any order due to WebSocket broadcast behavior
+    received = sorted([ws.recv() for _ in range(3)])
+    expected = sorted(["This is a broadcast message", "This is a message to self", "Whaaat??"])
+    assert received == expected
 
     ws.send("My name is?")
     assert ws.recv() == "Whooo??"
 
     ws.send("My name is?")
-    assert ws.recv() == "hi"
-    assert ws.recv() == "hello"
-    assert ws.recv() == "*chika* *chika* Slim Shady."
+    received = sorted([ws.recv() for _ in range(3)])
+    expected = sorted(["hi", "hello", "*chika* *chika* Slim Shady."])
+    assert received == expected
 
     # this will close the connection
     ws.send("test")


### PR DESCRIPTION
## Description
In the WebSocket test, an intermittent assertion error occurs when the received data order does not match the order in which messages were sent by the server.  
This issue appears mostly in CI environments due to timing or concurrency differences.

- This PR fixes #1188

## Summary
- Fixed a race condition in the WebSocket test by ensuring that message order is validated deterministically.
- The test no longer assumes strict ordering when it’s not guaranteed by the WebSocket protocol.
- Improves test reliability and eliminates random assertion failures in CI.

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved WebSocket integration tests to validate that a set of responses (in any order) matches expected messages.
  * Added assertion to verify the server reports connection closure after the final command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->