### PR TITLE
Fix badges in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![GitHub tag](https://img.shields.io/github/tag/sparckles/Robyn?include_prereleases=&sort=semver&color=black)](https://github.com/sparckles/Robyn/releases/)
 [![License](https://img.shields.io/badge/License-BSD_2.0-black)](https://github.com/sparckles/Robyn/blob/main/LICENSE)
 ![Python](https://img.shields.io/badge/Support-Version%20%E2%89%A5%203.9-brightgreen)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sparckles/Robyn)
 
 [![view - Documentation](https://img.shields.io/badge/view-Documentation-blue?style=for-the-badge)](https://robyn.tech/documentation)
 [![Discord](https://img.shields.io/discord/999782964143603713?label=discord&logo=discord&logoColor=white&style=for-the-badge&color=blue)](https://discord.gg/rkERZ5eNU8)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Robyn%20Guru-006BFF?style=for-the-badge)](https://gurubase.io/g/robyn)
-<a href="https://deepwiki.com/sparckles/Robyn"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" height="27"></a>
 
 Robyn is a High-Performance, Community-Driven, and Innovator Friendly Web Framework with a Rust runtime. You can learn more by checking our [community resources](https://robyn.tech/documentation/en/community-resources#talks)!
 


### PR DESCRIPTION
It is more balanced now :)

Before:
<img width="827" height="468" alt="Снимок экрана 2025-11-03 в 08 22 23" src="https://github.com/user-attachments/assets/7a323bf1-47ed-4561-8c96-9d6a76333cdc" />


After:
<img width="793" height="433" alt="Снимок экрана 2025-11-03 в 08 21 40" src="https://github.com/user-attachments/assets/46fae334-34c7-4202-88c6-868620f3ec55" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated DeepWiki badge formatting in documentation for improved rendering and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->