### PR TITLE
docs: remove typed vs untyped distinction

### DIFF
--- a/docs_src/src/pages/documentation/en/api_reference/advanced_features.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/advanced_features.mdx
@@ -14,17 +14,7 @@ Batman scaled his application across multiple cores for better performance. He u
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}  
-    from robyn import Robyn
-
-    app = Robyn(__file__)
-
-    @app.get("/")
-    async def h(request):
-        return f"hello to you, {request.ip_addr}"
-
-    ```
-    ```python {{ title: 'typed' }}  
+    ```python
     from robyn import Robyn, Request
 
     app = Robyn(__file__)

--- a/docs_src/src/pages/documentation/en/api_reference/authentication.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/authentication.mdx
@@ -19,15 +19,7 @@ As Batman found out, Robyn provides an easy way to add an authentication middlew
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/auth", auth_required=True)
-    async def auth(request: Request):
-        # This route method will only be executed if the user is authenticated
-        # Otherwise, a 401 response will be returned
-        return "Hello, world"
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     @app.get("/auth", auth_required=True)
     async def auth(request: Request):
         # This route method will only be executed if the user is authenticated
@@ -48,19 +40,7 @@ As Batman found out, Robyn provides an easy way to add an authentication middlew
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      class BasicAuthHandler(AuthenticationHandler):
-        def authenticate(self, request: Request) -> Optional[Identity]:
-            token = self.token_getter.get_token(request)
-            if token == "valid":
-                return Identity(claims={})
-            return None
-
-      app.configure_authentication(BasicAuthHandler(token_getter=BearerGetter()))
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       class BasicAuthHandler(AuthenticationHandler):
         def authenticate(self, request: Request) -> Optional[Identity]:
             token = self.token_getter.get_token(request)

--- a/docs_src/src/pages/documentation/en/api_reference/const_requests.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/const_requests.mdx
@@ -18,13 +18,7 @@ Robyn told Batman that you can pre-compute the response for each route. This wil
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      @app.get("/", const=True)
-      async def h():
-          return "Hello, world"
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       @app.get("/", const=True)
       async def h():
           return "Hello, world"
@@ -47,11 +41,7 @@ Robyn told Batman that he can use the `--workers` flag to scale the application 
   <Col sticky>
     <CodeGroup title="Request">
 
-      ```python {{ title: 'untyped' }}
-      python3 app.py --workers=N --process=M
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       python3 app.py --workers=N --process=M
       ```
     </CodeGroup>

--- a/docs_src/src/pages/documentation/en/api_reference/cors.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/cors.mdx
@@ -17,14 +17,7 @@ You can allow CORS for your application by adding the following code:
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-      from robyn import Robyn, ALLOW_CORS
-
-      app = Robyn(__file__)
-      ALLOW_CORS(app, origins = ["http://localhost:<PORT>/"])
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
       from robyn import Robyn, ALLOW_CORS
 
       app = Robyn(__file__)

--- a/docs_src/src/pages/documentation/en/api_reference/dependency_injection.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/dependency_injection.mdx
@@ -21,20 +21,7 @@ Application level dependency injection is used to inject dependencies into the a
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-      from robyn import Robyn, ALLOW_CORS
-
-      app = Robyn(__file__)
-      GLOBAL_DEPENDENCY = "GLOBAL DEPENDENCY"
-
-      app.inject_global(GLOBAL_DEPENDENCY=GLOBAL_DEPENDENCY)
-
-      @app.get("/sync/global_di")
-      def sync_global_di(request, global_dependencies):
-        return global_dependencies["GLOBAL_DEPENDENCY"]
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
       from robyn import Robyn, ALLOW_CORS
 
       app = Robyn(__file__)
@@ -62,20 +49,7 @@ Router level dependency injection is used to inject dependencies into the router
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-      from robyn import Robyn, ALLOW_CORS
-
-      app = Robyn(__file__)
-      ROUTER_DEPENDENCY = "ROUTER DEPENDENCY"
-
-      app.inject(ROUTER_DEPENDENCY=ROUTER_DEPENDENCY)
-
-      @app.get("/sync/global_di")
-      def sync_global_di(r, router_dependencies): # r is the request object
-        return router_dependencies["ROUTER_DEPENDENCY"]
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
       from robyn import Robyn, ALLOW_CORS, Request
 
       app = Robyn(__file__)

--- a/docs_src/src/pages/documentation/en/api_reference/exceptions.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/exceptions.mdx
@@ -9,13 +9,7 @@ Batman learned how to create custom error handlers for different exception types
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.exception
-    def handle_exception(error):
-        return Response(status_code=500, description=f"error msg: {error}", headers={})
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     @app.exception
     def handle_exception(error: Exception):
         return Response(status_code=500, description=f"error msg: {error}", headers={})

--- a/docs_src/src/pages/documentation/en/api_reference/file-uploads.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/file-uploads.mdx
@@ -16,19 +16,7 @@ Batman scaled his application across multiple cores for better performance. He u
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.post("/upload")
-    async def upload():
-      body = request.body
-      file = bytearray(body)
-
-      # write whatever filename
-      with open('test.txt', 'wb') as f:
-          f.write(body)
-
-      return {'message': 'success'}
-    ```
-    ```python {{ title: 'typed' }}
+    ```python
     @app.post("/upload")
     async def upload():
       body = request.body
@@ -56,15 +44,7 @@ Batman scaled his application across multiple cores for better performance. He u
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-
-    @app.post("/sync/multipart-file")
-    def sync_multipart_file(request: Request):
-        files = request.files
-        file_names = files.keys()
-        return {"file_names": list(file_names)}
-    ```
-    ```python {{ title: 'typed' }}
+    ```python
 
     @app.post("/sync/multipart-file")
     def sync_multipart_file(request: Request):
@@ -94,21 +74,7 @@ Batman scaled his application across multiple cores for better performance. He u
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn, serve_html
-
-    app = Robyn(__file__)
-
-
-    @app.get("/")
-    async def h(request):
-        return serve_html("./index.html")
-
-    app.start(port=8080)
-
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Robyn, Request, serve_html
 
     app = Robyn(__file__)
@@ -136,22 +102,7 @@ Speaking of HTML files, Batman wanted to serve simple HTML strings. He was sugge
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn, html
-
-    app = Robyn(__file__)
-
-
-    @app.get("/")
-    async def h(request):
-        html_string = "<h1>Hello World</h1>"
-        return html(html_string)
-
-    app.start(port=8080)
-
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Robyn, Request, html
 
     app = Robyn(__file__)
@@ -181,21 +132,7 @@ Now, that Batman was able to serve HTML files, he wanted to serve other files li
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn, serve_file
-
-    app = Robyn(__file__)
-
-
-    @app.get("/")
-    async def h(request):
-        return serve_file("./index.html", file_name="index.html") # file_name is optional
-
-    app.start(port=8080)
-
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Robyn, serve_file, Request
 
     app = Robyn(__file__)
@@ -224,23 +161,7 @@ After serving other files, Batman wanted to serve directories, e.g. to serve a R
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn, serve_file
-
-    app = Robyn(__file__)
-
-
-    app.serve_directory(
-        route="/test_dir",
-        directory_path=os.path.join(current_file_path, "build"),
-        index_file="index.html",
-    )
-
-    app.start(port=8080)
-
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Robyn, serve_file, Request
 
     app = Robyn(__file__)

--- a/docs_src/src/pages/documentation/en/api_reference/form_data.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/form_data.mdx
@@ -16,14 +16,7 @@ Batman uploaded some multipart form data and wanted to handle it using the follo
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.post("/upload")
-    async def upload(request):
-      form_data = request.form_data
-
-      return form_data
-    ```
-    ```python {{ title: 'typed' }}
+    ```python
     @app.post("/upload")
     async def upload(request: Request):
       form_data = request.form_data

--- a/docs_src/src/pages/documentation/en/api_reference/getting_started.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/getting_started.mdx
@@ -30,19 +30,7 @@ Robyn supports both synchronous and asynchronous request handlers, allowing you 
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn
-
-    app = Robyn(__file__)
-
-    @app.get("/")
-    def h(request):
-        return "Hello, world"
-
-    app.start(port=8080, host="0.0.0.0") # host is optional, defaults to 127.0.0.1
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Robyn, Request
 
     app = Robyn(__file__)
@@ -51,10 +39,7 @@ Robyn supports both synchronous and asynchronous request handlers, allowing you 
     def h(request: Request):
         return "Hello, world"
 
-    app.start(port=8080, host="0.0.0.0")
-
-
-
+    app.start(port=8080, host="0.0.0.0") # host is optional, defaults to 127.0.0.1
     ```
     </CodeGroup>
   </Col>
@@ -67,14 +52,7 @@ Robyn supports both synchronous and asynchronous request handlers, allowing you 
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      @app.get("/")
-      async def h(request):
-          return "Hello, world"
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       from robyn import Request
 
       @app.get("/")
@@ -756,19 +734,7 @@ Batman learned to customize response formats by returning dictionaries or using 
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.post("/dictionary")
-    async def dictionary(request):
-        return {
-            "status_code": 200,
-            "description": "This is a regular response",
-            "type": "text",
-            "headers": {"Header": "header_value"},
-        }
-
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Request
 
     @app.post("/dictionary")
@@ -779,7 +745,6 @@ Batman learned to customize response formats by returning dictionaries or using 
             "type": "text",
             "headers": {"Header": "header_value"},
         }
-
 
     ```
     </CodeGroup>
@@ -796,15 +761,7 @@ To use the Response object, he wrote:
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn.robyn import Response
-
-    @app.get("/response")
-    async def response(request):
-        return Response(status_code=200, headers=Headers({}), description="OK")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn.robyn import Response, Request
 
     @app.get("/response")
@@ -826,31 +783,7 @@ Batman then wanted to return a binary output from his application. He could do t
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/binary_output_response_sync")
-    def binary_output_response_sync(request):
-        return Response(
-            status_code=200,
-            headers={"Content-Type": "application/octet-stream"},
-            description="OK",
-        )
-
-
-    @app.get("/binary_output_async")
-    async def binary_output_async(request):
-        return b"OK"
-
-
-    @app.get("/binary_output_response_async")
-    async def binary_output_response_async(request):
-        return Response(
-            status_code=200,
-            headers={"Content-Type": "application/octet-stream"},
-            description="OK",
-        )
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Request, Response
 
     @app.get("/binary_output_response_sync")
@@ -898,17 +831,7 @@ Either, by using the `headers` field in the `Response` object:
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/")
-    def binary_output_response_sync(request):
-        return Response(
-            status_code=200,
-            headers={"Content-Type": "application/octet-stream"},
-            description="OK",
-        )
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Request
 
     @app.get("/")
@@ -933,11 +856,7 @@ Either, by using the `headers` field in the `Response` object:
   <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.add_response_header("content-type", "application/json")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.add_response_header("content-type", "application/json")
     ```
     </CodeGroup>
@@ -951,11 +870,7 @@ Either, by using the `headers` field in the `Response` object:
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.set_response_header("content-type", "application/json")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.set_response_header("content-type", "application/json")
     ```
     </CodeGroup>
@@ -968,11 +883,7 @@ To prevent the headers from getting applied to certain endpoints, you can use th
 <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.exclude_response_headers_for(["/login", "/signup"])
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.exclude_response_headers_for(["/login", "/signup"])
     ```
     </CodeGroup>
@@ -990,17 +901,7 @@ Robyn provides a complete cookie API following RFC 6265. Set cookies using the `
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Response, Headers
-
-    @app.get("/")
-    def set_session(request):
-        response = Response(200, Headers({}), "Welcome!")
-        response.set_cookie(key="session", value="abc123")
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response, Headers
 
     @app.get("/")
@@ -1030,23 +931,7 @@ You can set additional cookie attributes for security and control:
 
     <CodeGroup title="Request" tag="GET" label="/secure-cookie">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/login")
-    def login(request):
-        response = Response(200, Headers({}), "Logged in")
-        response.set_cookie(
-            key="auth_token",
-            value="secret123",
-            path="/",
-            max_age=3600,        # 1 hour
-            secure=True,         # HTTPS only
-            http_only=True,      # No JavaScript access
-            same_site="Strict",  # CSRF protection
-        )
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response, Headers
 
     @app.get("/login")
@@ -1077,15 +962,7 @@ To delete a cookie from the browser, use the `delete` method on the cookies coll
 
     <CodeGroup title="Request" tag="GET" label="/logout">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/logout")
-    def logout(request):
-        response = Response(200, Headers({}), "Logged out")
-        response.cookies.delete("auth_token")
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response, Headers
 
     @app.get("/logout")
@@ -1108,28 +985,7 @@ You can iterate over cookies or access them by name:
 
     <CodeGroup title="Request" tag="GET" label="/cookies">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/debug")
-    def debug_cookies(request):
-        response = Response(200, Headers({}), "Cookies set")
-        response.set_cookie("a", "1")
-        response.set_cookie("b", "2")
-        
-        # Get all cookie names
-        names = response.cookies.keys()
-        
-        # Iterate over cookies
-        for name in response.cookies:
-            print(f"Cookie: {name}")
-        
-        # Check if cookie exists
-        if "a" in response.cookies:
-            print("Cookie 'a' exists")
-            
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response, Headers
 
     @app.get("/debug")
@@ -1171,25 +1027,7 @@ Either, by using the `headers` field in the `Request` object:
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/")
-    def binary_output_response_sync(request):
-      headers = request.headers
-
-      print("These are the request headers: ", headers)
-      existing_header = headers.get("exisiting_header")
-      existing_header = headers.get("exisiting_header", "default_value")
-      exisiting_header = headers["exisiting_header"] # This syntax is also valid
-
-      headers.set("modified", "modified_value")
-      headers["new_header"] = "new_value" # This syntax is also valid
-
-      print("These are the modified request headers: ", headers)
-      
-      return ""
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Request
 
     @app.get("/")
@@ -1222,11 +1060,7 @@ Or by using the global Request Headers:
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.add_request_header("server", "robyn")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.add_request_header("server", "robyn")
     ```
     </CodeGroup>
@@ -1242,11 +1076,7 @@ Or by using the global Request Headers:
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.set_request_header("server", "robyn")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.set_request_header("server", "robyn")
     ```
     </CodeGroup>
@@ -1266,15 +1096,7 @@ After learning about response formats and headers, Batman learned to set status 
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import status_codes
-
-    @app.get("/response")
-    async def response(request):
-        return Response(status_code=status_codes.HTTP_200_OK, headers=Headers({}), description="OK")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import status_codes, Request
 
 

--- a/docs_src/src/pages/documentation/en/api_reference/middlewares.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/middlewares.mdx
@@ -18,16 +18,12 @@ Batman was excited to learn that he could add events as functions as well as dec
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
+    ```python
     async def startup_handler():
       print("Starting up")
 
     app.startup_handler(startup_handler)
 
-
-    ```
-
-    ```python {{title: 'typed'}}
     @app.shutdown_handler
     def shutdown_handler():
         print("Shutting down")
@@ -45,14 +41,7 @@ Batman was excited to learn that he could add events as functions as well as dec
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      @app.get("/")
-      async def h(request):
-          return "Hello, world"
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       from robyn import Request 
 
       @app.get("/")
@@ -88,19 +77,7 @@ Batman was excited to learn that he could add events as functions as well as dec
 
     <CodeGroup title="Request" tag="POST" label="/http_requests">
 
-    ```python {{ title: 'untyped' }}
-    @app.before_request("/")
-    async def hello_before_request(request: Request):
-        request.headers["before"] = "sync_before_request"
-        return request
-
-    @app.after_request("/")
-    def hello_after_request(response: Response):
-        response.headers.set("after", "sync_after_request")
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response
 
     @app.before_request("/")

--- a/docs_src/src/pages/documentation/en/api_reference/multiprocess_execution.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/multiprocess_execution.mdx
@@ -21,33 +21,7 @@ If one needs a variable to be protected within a process, while accessing it fro
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}  
-        import threading
-        import time
-        from multiprocessing import Value
-
-        from robyn import Robyn, Request
-
-        app = Robyn(__file__)
-
-        count = Value("i", 0)
-
-        def counter():
-            while True:
-                count.value += 1
-                time.sleep(0.2)
-                print(count.value, "added 1")
-
-        @app.get("/")
-        def index(request):
-            return f"{count.value}"
-
-        threading.Thread(target=counter, daemon=True).start()
-
-        app.start()
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
         import threading
         import time
         from multiprocessing import Value

--- a/docs_src/src/pages/documentation/en/api_reference/openapi.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/openapi.mdx
@@ -29,62 +29,7 @@ python app.py --disable-openapi
 
 <CodeGroup title="Basic App">
 
-```python {{ title: 'untyped' }}
-from robyn import Robyn
-from robyn.robyn import QueryParams
-
-app = Robyn(
-    file_object=__file__,
-    openapi=OpenAPI(
-        info=OpenAPIInfo(
-            title="Sample App",
-            description="This is a sample server application.",
-            termsOfService="https://example.com/terms/",
-            version="1.0.0",
-            contact=Contact(
-                name="API Support",
-                url="https://www.example.com/support",
-                email="support@example.com",
-            ),
-            license=License(
-                name="BSD2.0",
-                url="https://opensource.org/license/bsd-2-clause",
-            ),
-            externalDocs=ExternalDocumentation(description="Find more info here", url="https://example.com/"),
-            components=Components(),
-        ),
-    ),
-)
-
-
-@app.get("/")
-async def welcome():
-    """welcome endpoint"""
-    return "hi"
-
-
-class GetRequestParams(QueryParams):
-    appointment_id: str
-    year: int
-
-
-@app.get("/api/v1/name", openapi_name="Name Route", openapi_tags=["Name"])
-async def get(r, query_params: GetRequestParams):
-    """Get Name by ID"""
-    return r.query_params
-
-
-@app.delete("/users/:name", openapi_tags=["Name"])
-async def delete(r):
-    """Delete Name by ID"""
-    return r.path_params
-
-
-if __name__ == "__main__":
-    app.start()
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.robyn import QueryParams
 
 from robyn import Robyn, Request
@@ -146,40 +91,7 @@ if __name__ == "__main__":
 
 <CodeGroup title="Subrouters">
 
-```python {{ title: 'untyped' }}
-from robyn import SubRouter
-from robyn.robyn import QueryParams
-
-subrouter = SubRouter(__name__, prefix="/sub")
-
-
-@subrouter.get("/")
-async def subrouter_welcome():
-    """welcome subrouter"""
-    return "hiiiiii subrouter"
-
-
-class SubRouterGetRequestParams(QueryParams):
-    _id: int
-    value: str
-
-
-@subrouter.get("/name")
-async def subrouter_get(r, query_params: SubRouterGetRequestParams):
-    """Get Name by ID"""
-    return r.query_params
-
-
-@subrouter.delete("/:name")
-async def subrouter_delete(r):
-    """Delete Name by ID"""
-    return r.path_params
-
-
-app.include_router(subrouter)
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.robyn import QueryParams
 
 from robyn import Request, SubRouter
@@ -221,38 +133,7 @@ We support all the params mentioned in the latest OpenAPI specifications (https:
 
 <CodeGroup title="Request & Response Body">
 
-```python {{ title: 'untyped' }}
-from robyn.types import JSONResponse, Body
-
-class Initial(Body):
-    is_present: bool
-    letter: Optional[str]
-
-
-class FullName(Body):
-    first: str
-    second: str
-    initial: Initial
-
-
-class CreateItemBody(Body):
-    name: FullName
-    description: str
-    price: float
-    tax: float
-
-
-class CreateResponse(JSONResponse):
-    success: bool
-    items_changed: int
-
-
-@app.post("/")
-def create_item(request: Request, body: CreateItemBody) -> CreateResponse:
-    return CreateResponse(success=True, items_changed=2)
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.types import JSONResponse, Body
 
 class Initial(Body):

--- a/docs_src/src/pages/documentation/en/api_reference/redirection.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/redirection.mdx
@@ -8,7 +8,7 @@ Batman wanted to redirect some endpoints to others. Robyn helped him do so by th
   <Col sticky>
     <CodeGroup title="Request">
 
-      ```python {{title: 'untyped'}}
+      ```python
       from robyn import Robyn, Response
       app = Robyn(__file__)
 

--- a/docs_src/src/pages/documentation/en/api_reference/request_object.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/request_object.mdx
@@ -50,24 +50,7 @@ identity (Optional[Identity]): The identity of the client
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @dataclass
-    class Request:
-      """
-      query_params: QueryParams
-      headers: Headers
-      path_params: dict[str, str]
-      body: Union[str, bytes]
-      method: str
-      url: Url
-      form_data: dict[str, str]
-      files: dict[str, bytes]
-      ip_addr: Optional[str]
-      identity: Optional[Identity]
-      """
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     @dataclass
     class Request:
       """

--- a/docs_src/src/pages/documentation/en/api_reference/templating.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/templating.mdx
@@ -16,22 +16,7 @@ Batman was excited to learn that he could add events as functions as well as dec
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{title: 'untyped'}}
-    from robyn.templating import JinjaTemplate
-
-    current_file_path = pathlib.Path(__file__).parent.resolve()
-    JINJA_TEMPLATE = JinjaTemplate(os.path.join(current_file_path, "templates"))
-
-    @app.get("/template_render")
-    def template_render():
-        context = {"framework": "Robyn", "templating_engine": "Jinja2"}
-
-        template = JINJA_TEMPLATE.render_template(template_name="test.html", **context)
-        return template
-
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn.templating import JinjaTemplate
 
     current_file_path = pathlib.Path(__file__).parent.resolve()
@@ -84,11 +69,7 @@ To do that, you need to import the `TemplateInterface` from `robyn.templating`
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      from robyn.templating import TemplateInterface
-      ```
-
-      ```python {{ title: 'typed' }}
+      ```python
       from robyn.templating import TemplateInterface
       ```
     </CodeGroup>
@@ -103,20 +84,7 @@ Then You need to have a `render_template` method inside your implementation. So,
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      class JinjaTemplate(TemplateInterface):
-        def __init__(self, directory, encoding="utf-8", followlinks=False):
-            self.env = Environment(
-                loader=FileSystemLoader(
-                    searchpath=directory, encoding=encoding, followlinks=followlinks
-                )
-            )
-
-        def render_template(self, template_name, **kwargs):
-            return self.env.get_template(template_name).render(**kwargs)
-      ```
-
-      ```python {{ title: 'typed' }}
+      ```python
       class JinjaTemplate(TemplateInterface):
         def __init__(self, directory, encoding="utf-8", followlinks=False):
             self.env = Environment(

--- a/docs_src/src/pages/documentation/en/api_reference/using_rust_directly.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/using_rust_directly.mdx
@@ -14,11 +14,7 @@ The first thing you need to is to create a Rust file. Let's call it `hello_world
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    python -m robyn --create-rust-file hello_world
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     python -m robyn --create-rust-file hello_world
     ```
 
@@ -93,13 +89,7 @@ The first thing you need to is to create a Rust file. Let's call it `hello_world
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      from hello_world import square
-
-      print(square(5))
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       from hello_world import square
 
       print(square(5))
@@ -112,11 +102,7 @@ The first thing you need to is to create a Rust file. Let's call it `hello_world
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      python -m robyn --compile-rust-path "." --dev
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       python -m robyn --compile-rust-path "." --dev
       ```
     </CodeGroup>

--- a/docs_src/src/pages/documentation/en/api_reference/websockets.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/websockets.mdx
@@ -16,7 +16,7 @@ To handle real-time bidirectional communication, Batman learned how to work with
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
+    ```python
     from robyn import Robyn, jsonify, WebSocket
 
     app = Robyn(__file__)
@@ -33,28 +33,6 @@ To handle real-time bidirectional communication, Batman learned how to work with
     @websocket.on("connect")
     def message():
         return "Connected to ws"
-
-
-    ```
-
-    ```python {{title: 'typed'}}
-    from robyn import Robyn, jsonify, WebSocket
-
-    app = Robyn(__file__)
-    websocket = WebSocket(app, "/web_socket")
-
-    @websocket.on("message")
-    def connect():
-        return "Hello world, from ws"
-
-    @websocket.on("close")
-    def close():
-        return "Goodbye world, from ws"
-
-    @websocket.on("connect")
-    def message():
-        return "Connected to ws"
-
 
     ```
     </CodeGroup>
@@ -76,31 +54,7 @@ To handle real-time bidirectional communication, Batman learned how to work with
   <Col sticky>
     <CodeGroup title="Optional Returns" tag="WebSocket" label="/web_socket">
 
-      ```python {{ title: 'untyped' }}
-      from robyn import Robyn, WebSocket
-
-      app = Robyn(__file__)
-      websocket = WebSocket(app, "/web_socket")
-
-      @websocket.on("connect")
-      async def connect():
-          # No return needed - just log the connection
-          print("Client connected")
-
-      @websocket.on("message")
-      def message(ws, msg):
-          # Process message without responding
-          process_analytics(msg)
-          # No return statement needed
-
-      @websocket.on("close")
-      async def close():
-          # Explicitly return None - no message sent
-          cleanup_resources()
-          return None
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       from robyn import Robyn, WebSocket, WebSocketConnector
 
       app = Robyn(__file__)
@@ -135,22 +89,11 @@ To handle real-time bidirectional communication, Batman learned how to work with
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            ws.sync_send_to(websocket_id, "This is a message to self")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
             websocket_id = ws.id
-            state = websocket_state[websocket_id]
             ws.sync_send_to(websocket_id, "This is a message to self")
             return ""
 
@@ -168,22 +111,11 @@ To handle real-time bidirectional communication, Batman learned how to work with
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        async def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            await ws.async_send_to(websocket_id, "This is a message to self")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         async def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
             websocket_id = ws.id
-            state = websocket_state[websocket_id]
             await ws.async_send_to(websocket_id, "This is a message to self")
             return ""
 
@@ -200,17 +132,7 @@ To handle real-time bidirectional communication, Batman learned how to work with
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            ws.sync_broadcast("This is a message to self")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
@@ -230,17 +152,7 @@ To handle real-time bidirectional communication, Batman learned how to work with
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        async def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            await ws.async_broadcast("This is a message to self")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         async def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
@@ -260,18 +172,7 @@ To handle real-time bidirectional communication, Batman learned how to work with
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world?name=gordon&desg=commissioner">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        async def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            if (ws.query_params.get("name") == "gordon" and ws.query_params.get("desg") == "commissioner"):
-              ws.sync_broadcast("Gordon authorized to login!")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         async def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
@@ -301,16 +202,7 @@ This method is useful for scenarios where you need to programmatically end a Web
   <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      @websocket.on("message")
-      def message(ws, msg):
-          if msg == "disconnect":
-              ws.close()
-              return "Closing connection"
-          return "Message received"
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       @websocket.on("message")
       def message(ws: WebSocketConnector, msg: str) -> str:
           if msg == "disconnect":

--- a/docs_src/src/pages/documentation/en/example_app/openapi.mdx
+++ b/docs_src/src/pages/documentation/en/example_app/openapi.mdx
@@ -29,62 +29,7 @@ python app.py --disable-openapi
 
 <CodeGroup title="Basic App">
 
-```python {{ title: 'untyped' }}
-from robyn import Robyn
-from robyn.robyn import QueryParams
-
-app = Robyn(
-    file_object=__file__,
-    openapi=OpenAPI(
-        info=OpenAPIInfo(
-            title="Sample App",
-            description="This is a sample server application.",
-            termsOfService="https://example.com/terms/",
-            version="1.0.0",
-            contact=Contact(
-                name="API Support",
-                url="https://www.example.com/support",
-                email="support@example.com",
-            ),
-            license=License(
-                name="BSD2.0",
-                url="https://opensource.org/license/bsd-2-clause",
-            ),
-            externalDocs=ExternalDocumentation(description="Find more info here", url="https://example.com/"),
-            components=Components(),
-        ),
-    ),
-)
-
-
-@app.get("/")
-async def welcome():
-    """welcome endpoint"""
-    return "hi"
-
-
-class GetRequestParams(QueryParams):
-    appointment_id: str
-    year: int
-
-
-@app.get("/api/v1/name", openapi_name="Name Route", openapi_tags=["Name"])
-async def get(r, query_params: GetRequestParams):
-    """Get Name by ID"""
-    return r.query_params
-
-
-@app.delete("/users/:name", openapi_tags=["Name"])
-async def delete(r):
-    """Delete Name by ID"""
-    return r.path_params
-
-
-if __name__ == "__main__":
-    app.start()
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.robyn import QueryParams
 
 from robyn import Robyn, Request
@@ -146,40 +91,7 @@ if __name__ == "__main__":
 
 <CodeGroup title="Subrouters">
 
-```python {{ title: 'untyped' }}
-from robyn import SubRouter
-from robyn.robyn import QueryParams
-
-subrouter = SubRouter(__name__, prefix="/sub")
-
-
-@subrouter.get("/")
-async def subrouter_welcome():
-    """welcome subrouter"""
-    return "hiiiiii subrouter"
-
-
-class SubRouterGetRequestParams(QueryParams):
-    _id: int
-    value: str
-
-
-@subrouter.get("/name")
-async def subrouter_get(r, query_params: SubRouterGetRequestParams):
-    """Get Name by ID"""
-    return r.query_params
-
-
-@subrouter.delete("/:name")
-async def subrouter_delete(r):
-    """Delete Name by ID"""
-    return r.path_params
-
-
-app.include_router(subrouter)
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.robyn import QueryParams
 
 from robyn import Request, SubRouter
@@ -221,38 +133,7 @@ We support all the params mentioned in the latest OpenAPI specifications (https:
 
 <CodeGroup title="Request & Response Body">
 
-```python {{ title: 'untyped' }}
-from robyn.types import JSONResponse, Body
-
-class Initial(Body):
-    is_present: bool
-    letter: Optional[str]
-
-
-class FullName(Body):
-    first: str
-    second: str
-    initial: Initial
-
-
-class CreateItemBody(Body):
-    name: FullName
-    description: str
-    price: float
-    tax: float
-
-
-class CreateResponse(JSONResponse):
-    success: bool
-    items_changed: int
-
-
-@app.post("/")
-def create_item(request: Request, body: CreateItemBody) -> CreateResponse:
-    return CreateResponse(success=True, items_changed=2)
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.types import JSONResponse, Body
 
 class Initial(Body):

--- a/docs_src/src/pages/documentation/zh/api_reference/advanced_features.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/advanced_features.mdx
@@ -13,17 +13,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn
-
-    app = Robyn(__file__)
-
-    @app.get("/")
-    async def h(request):
-        return f"hello to you, {request.ip_addr}"
-
-    ```
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Robyn, Request
 
     app = Robyn(__file__)

--- a/docs_src/src/pages/documentation/zh/api_reference/authentication.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/authentication.mdx
@@ -14,21 +14,12 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
+    ```python
     @app.get("/auth", auth_required=True)
     async def auth(request: Request):
         # This route method will only be executed if the user is authenticated
         # Otherwise, a 401 response will be returned
         return "Hello, world"
-    ```
-
-    ```python {{title: 'typed'}}
-    @app.get("/auth", auth_required=True)
-    async def auth(request: Request):
-        # This route method will only be executed if the user is authenticated
-        # Otherwise, a 401 response will be returned
-        return "Hello, world"
-
     ```
     </CodeGroup>
 
@@ -43,19 +34,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      class BasicAuthHandler(AuthenticationHandler):
-        def authenticate(self, request: Request) -> Optional[Identity]:
-            token = self.token_getter.get_token(request)
-            if token == "valid":
-                return Identity(claims={})
-            return None
-
-      app.configure_authentication(BasicAuthHandler(token_getter=BearerGetter()))
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       class BasicAuthHandler(AuthenticationHandler):
         def authenticate(self, request: Request) -> Optional[Identity]:
             token = self.token_getter.get_token(request)

--- a/docs_src/src/pages/documentation/zh/api_reference/const_requests.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/const_requests.mdx
@@ -14,17 +14,10 @@ Robyn 告诉蝙蝠侠，可以为每个路由预处理响应，这样即使在�
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
+      ```python
       @app.get("/", const=True)
       async def h():
           return "Hello, world"
-      ```
-
-      ```python {{title: 'typed'}}
-      @app.get("/", const=True)
-      async def h():
-          return "Hello, world"
-
       ```
     </CodeGroup>
 
@@ -43,11 +36,7 @@ Robyn 告诉蝙蝠侠，可以使用 `--workers` 参数将应用程序扩展到�
   <Col sticky>
     <CodeGroup title="Request">
 
-      ```python {{ title: 'untyped' }}
-      python3 app.py --workers=N --process=M
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       python3 app.py --workers=N --process=M
       ```
     </CodeGroup>

--- a/docs_src/src/pages/documentation/zh/api_reference/cors.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/cors.mdx
@@ -15,14 +15,7 @@ You can allow CORS for your application by adding the following code:
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-      from robyn import Robyn, ALLOW_CORS
-
-      app = Robyn(__file__)
-      ALLOW_CORS(app, origins = ["http://localhost:<PORT>/"])
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
       from robyn import Robyn, ALLOW_CORS
 
       app = Robyn(__file__)

--- a/docs_src/src/pages/documentation/zh/api_reference/dependency_injection.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/dependency_injection.mdx
@@ -17,7 +17,7 @@ Robyn 提供了两种依赖注入方式：
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
+    ```python
       from robyn import Robyn, ALLOW_CORS
 
       app = Robyn(__file__)
@@ -28,20 +28,6 @@ Robyn 提供了两种依赖注入方式：
       @app.get("/sync/global_di")
       def sync_global_di(request, global_dependencies):
         return global_dependencies["GLOBAL_DEPENDENCY"]
-    ```
-
-    ```python {{ title: 'typed' }}
-      from robyn import Robyn, ALLOW_CORS
-
-      app = Robyn(__file__)
-      GLOBAL_DEPENDENCY = "GLOBAL DEPENDENCY"
-
-      app.inject_global(GLOBAL_DEPENDENCY=GLOBAL_DEPENDENCY)
-
-      @app.get("/sync/global_di")
-      def sync_global_di(request, global_dependencies):
-        return global_dependencies["GLOBAL_DEPENDENCY"]
-
     ```
     </CodeGroup>
 
@@ -58,20 +44,7 @@ Robyn 提供了两种依赖注入方式：
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-      from robyn import Robyn, ALLOW_CORS
-
-      app = Robyn(__file__)
-      ROUTER_DEPENDENCY = "ROUTER DEPENDENCY"
-
-      app.inject(ROUTER_DEPENDENCY=ROUTER_DEPENDENCY)
-
-      @app.get("/sync/global_di")
-      def sync_global_di(r, router_dependencies): # r is the request object
-        return router_dependencies["ROUTER_DEPENDENCY"]
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
       from robyn import Robyn, ALLOW_CORS, Request
 
       app = Robyn(__file__)

--- a/docs_src/src/pages/documentation/zh/api_reference/exceptions.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/exceptions.mdx
@@ -9,13 +9,7 @@
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.exception
-    def handle_exception(error):
-        return Response(status_code=500, description=f"error msg: {error}", headers={})
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     @app.exception
     def handle_exception(error: Exception):
         return Response(status_code=500, description=f"error msg: {error}", headers={})

--- a/docs_src/src/pages/documentation/zh/api_reference/file-uploads.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/file-uploads.mdx
@@ -15,19 +15,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.post("/upload")
-    async def upload():
-      body = request.body
-      file = bytearray(body)
-
-      # write whatever filename
-      with open('test.txt', 'wb') as f:
-          f.write(body)
-
-      return {'message': 'success'}
-    ```
-    ```python {{ title: 'typed' }}
+    ```python
     @app.post("/upload")
     async def upload():
       body = request.body
@@ -55,15 +43,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-
-    @app.post("/sync/multipart-file")
-    def sync_multipart_file(request: Request):
-        files = request.files
-        file_names = files.keys()
-        return {"file_names": list(file_names)}
-    ```
-    ```python {{ title: 'typed' }}
+    ```python
 
     @app.post("/sync/multipart-file")
     def sync_multipart_file(request: Request):
@@ -93,21 +73,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn, serve_html
-
-    app = Robyn(__file__)
-
-
-    @app.get("/")
-    async def h(request):
-        return serve_html("./index.html")
-
-    app.start(port=8080)
-
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Robyn, Request, serve_html
 
     app = Robyn(__file__)
@@ -135,22 +101,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn, html
-
-    app = Robyn(__file__)
-
-
-    @app.get("/")
-    async def h(request):
-        html_string = "<h1>Hello World</h1>"
-        return html(html_string)
-
-    app.start(port=8080)
-
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Robyn, Request, html
 
     app = Robyn(__file__)
@@ -179,21 +130,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn, serve_file
-
-    app = Robyn(__file__)
-
-
-    @app.get("/")
-    async def h(request):
-        return serve_file("./index.html", file_name="index.html") # file_name is optional
-
-    app.start(port=8080)
-
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Robyn, serve_file, Request
 
     app = Robyn(__file__)
@@ -222,23 +159,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn, serve_file
-
-    app = Robyn(__file__)
-
-
-    app.serve_directory(
-        route="/test_dir",
-        directory_path=os.path.join(current_file_path, "build"),
-        index_file="index.html",
-    )
-
-    app.start(port=8080)
-
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Robyn, serve_file, Request
 
     app = Robyn(__file__)

--- a/docs_src/src/pages/documentation/zh/api_reference/form_data.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/form_data.mdx
@@ -14,14 +14,7 @@ export const description = '在此页面中，我们将深入了解如何处理�
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.post("/upload")
-    async def upload(request):
-      form_data = request.form_data
-
-      return form_data
-    ```
-    ```python {{ title: 'typed' }}
+    ```python
     @app.post("/upload")
     async def upload(request: Request):
       form_data = request.form_data

--- a/docs_src/src/pages/documentation/zh/api_reference/getting_started.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/getting_started.mdx
@@ -13,19 +13,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn
-
-    app = Robyn(__file__)
-
-    @app.get("/")
-    def h(request):
-        return "Hello, world"
-
-    app.start(port=8080, host="0.0.0.0") # host 是可选的，默认为 127.0.0.1
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Robyn, Request
 
     app = Robyn(__file__)
@@ -34,10 +22,7 @@ export const description =
     def h(request: Request):
         return "Hello, world"
 
-    app.start(port=8080, host="0.0.0.0")
-
-
-
+    app.start(port=8080, host="0.0.0.0") # host 是可选的，默认为 127.0.0.1
     ```
     </CodeGroup>
 
@@ -51,14 +36,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      @app.get("/")
-      async def h(request):
-          return "Hello, world"
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       from robyn import Request
 
       @app.get("/")
@@ -166,14 +144,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.post("/")
-    async def h(request):
-        return "Hello World"
-
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Request
 
     @app.post("/")
@@ -200,16 +171,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import jsonify
-
-    @app.post("/jsonify")
-    async def json(request):
-        return {"hello": "world"}
-
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import jsonify, Request
 
 
@@ -239,27 +201,14 @@ Robyn 向蝙蝠侠展示了如何从请求中访问路径参数和查询参数�
 
     <CodeGroup title="Request" tag="POST" label="/http_requests">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import jsonify
-
-    @app.post("/jsonify/:id")
-    async def json(request, path_params):
-        print(request.path_params["id"])
-        print(path_params["id"])
-        assert request.path_params["id"] == path_params["id"]
-        return {"hello": "world"}
-
-
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import jsonify
     from robyn.types import PathParams
 
     @app.post("/jsonify/:id")
     async def json(req_obj: Request, path_parameters: PathParams):
         print(req_obj.path_params["id"])
-        print(path_params["id"])
+        print(path_parameters["id"])
         assert req_obj.path_params["id"] == path_parameters["id"]
         return {"hello": "world"}
 
@@ -281,15 +230,7 @@ Robyn 向蝙蝠侠展示了如何从请求中访问路径参数和查询参数�
 
     <CodeGroup title="Request" tag="POST" label="/http_requests">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/query")
-    async def query_get(request, query_params):
-        query_data = query_params.to_dict()
-        assert query_data == request.query_params.to_dict()
-        return jsonify(query_data)
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request
     from robyn.robyn import QueryParams
 
@@ -383,19 +324,7 @@ Robyn 向蝙蝠侠演示了访问请求参数的不同语法示例：
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.post("/dictionary")
-    async def dictionary(request):
-        return {
-            "status_code": 200,
-            "description": "This is a regular response",
-            "type": "text",
-            "headers": {"Header": "header_value"},
-        }
-
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Request
 
     @app.post("/dictionary")
@@ -406,7 +335,6 @@ Robyn 向蝙蝠侠演示了访问请求参数的不同语法示例：
             "type": "text",
             "headers": {"Header": "header_value"},
         }
-
 
     ```
     </CodeGroup>
@@ -424,15 +352,7 @@ Robyn 向蝙蝠侠演示了访问请求参数的不同语法示例：
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn.robyn import Response
-
-    @app.get("/response")
-    async def response(request):
-        return Response(status_code=200, headers=Headers({}), description="OK")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn.robyn import Response, Request
 
     @app.get("/response")
@@ -455,31 +375,7 @@ Robyn 向蝙蝠侠演示了访问请求参数的不同语法示例：
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/binary_output_response_sync")
-    def binary_output_response_sync(request):
-        return Response(
-            status_code=200,
-            headers={"Content-Type": "application/octet-stream"},
-            description="OK",
-        )
-
-
-    @app.get("/binary_output_async")
-    async def binary_output_async(request):
-        return b"OK"
-
-
-    @app.get("/binary_output_response_async")
-    async def binary_output_response_async(request):
-        return Response(
-            status_code=200,
-            headers={"Content-Type": "application/octet-stream"},
-            description="OK",
-        )
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Request, Response
 
     @app.get("/binary_output_response_sync")
@@ -525,17 +421,7 @@ Robyn 向蝙蝠侠演示了访问请求参数的不同语法示例：
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/")
-    def binary_output_response_sync(request):
-        return Response(
-            status_code=200,
-            headers={"Content-Type": "application/octet-stream"},
-            description="OK",
-        )
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Request
 
     @app.get("/")
@@ -561,11 +447,7 @@ Robyn 向蝙蝠侠演示了访问请求参数的不同语法示例：
   <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.add_response_header("content-type", "application/json")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.add_response_header("content-type", "application/json")
     ```
     </CodeGroup>
@@ -579,11 +461,7 @@ Robyn 向蝙蝠侠演示了访问请求参数的不同语法示例：
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.set_response_header("content-type", "application/json")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.set_response_header("content-type", "application/json")
     ```
     </CodeGroup>
@@ -596,11 +474,7 @@ Robyn 向蝙蝠侠演示了访问请求参数的不同语法示例：
 <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.exclude_response_headers_for(["/login", "/signup"])
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.exclude_response_headers_for(["/login", "/signup"])
     ```
     </CodeGroup>
@@ -618,17 +492,7 @@ Robyn 提供了符合 RFC 6265 标准的完整 Cookie API。使用 Response 对�
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Response, Headers
-
-    @app.get("/")
-    def set_session(request):
-        response = Response(200, Headers({}), "Welcome!")
-        response.set_cookie(key="session", value="abc123")
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response, Headers
 
     @app.get("/")
@@ -658,23 +522,7 @@ Robyn 提供了符合 RFC 6265 标准的完整 Cookie API。使用 Response 对�
 
     <CodeGroup title="Request" tag="GET" label="/secure-cookie">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/login")
-    def login(request):
-        response = Response(200, Headers({}), "Logged in")
-        response.set_cookie(
-            key="auth_token",
-            value="secret123",
-            path="/",
-            max_age=3600,        # 1 小时
-            secure=True,         # 仅 HTTPS
-            http_only=True,      # 禁止 JavaScript 访问
-            same_site="Strict",  # CSRF 保护
-        )
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response, Headers
 
     @app.get("/login")
@@ -705,15 +553,7 @@ Robyn 提供了符合 RFC 6265 标准的完整 Cookie API。使用 Response 对�
 
     <CodeGroup title="Request" tag="GET" label="/logout">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/logout")
-    def logout(request):
-        response = Response(200, Headers({}), "Logged out")
-        response.cookies.delete("auth_token")
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response, Headers
 
     @app.get("/logout")
@@ -736,28 +576,7 @@ Robyn 提供了符合 RFC 6265 标准的完整 Cookie API。使用 Response 对�
 
     <CodeGroup title="Request" tag="GET" label="/cookies">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/debug")
-    def debug_cookies(request):
-        response = Response(200, Headers({}), "Cookies set")
-        response.set_cookie("a", "1")
-        response.set_cookie("b", "2")
-        
-        # 获取所有 Cookie 名称
-        names = response.cookies.keys()
-        
-        # 遍历 Cookie
-        for name in response.cookies:
-            print(f"Cookie: {name}")
-        
-        # 检查 Cookie 是否存在
-        if "a" in response.cookies:
-            print("Cookie 'a' exists")
-            
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response, Headers
 
     @app.get("/debug")
@@ -797,25 +616,7 @@ Robyn 提供了符合 RFC 6265 标准的完整 Cookie API。使用 Response 对�
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @app.get("/")
-    def binary_output_response_sync(request):
-      headers = request.headers
-
-      print("These are the request headers: ", headers)
-      existing_header = headers.get("exisiting_header")
-      existing_header = headers.get("exisiting_header", "default_value")
-      exisiting_header = headers["exisiting_header"] # This syntax is also valid
-
-      headers.set("modified", "modified_value")
-      headers["new_header"] = "new_value" # This syntax is also valid
-
-      print("These are the modified request headers: ", headers)
-
-      return ""
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Request
 
     @app.get("/")
@@ -833,7 +634,6 @@ Robyn 提供了符合 RFC 6265 标准的完整 Cookie API。使用 Response 对�
       print("These are the modified request headers: ", headers)
 
       return ""
-
     ```
     </CodeGroup>
 
@@ -848,11 +648,7 @@ Robyn 提供了符合 RFC 6265 标准的完整 Cookie API。使用 Response 对�
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.add_request_header("server", "robyn")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.add_request_header("server", "robyn")
     ```
     </CodeGroup>
@@ -868,11 +664,7 @@ Robyn 提供了符合 RFC 6265 标准的完整 Cookie API。使用 Response 对�
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    app.set_request_header("server", "robyn")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     app.set_request_header("server", "robyn")
     ```
     </CodeGroup>
@@ -892,15 +684,7 @@ Robyn 提供了符合 RFC 6265 标准的完整 Cookie API。使用 Response 对�
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import status_codes
-
-    @app.get("/response")
-    async def response(request):
-        return Response(status_code=status_codes.HTTP_200_OK, headers=Headers({}), description="OK")
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import status_codes, Request
 
 

--- a/docs_src/src/pages/documentation/zh/api_reference/middlewares.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/middlewares.mdx
@@ -20,20 +20,15 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
+    ```python
     async def startup_handler():
       print("Starting up")
 
     app.startup_handler(startup_handler)
 
-
-    ```
-
-    ```python {{title: 'typed'}}
     @app.shutdown_handler
     def shutdown_handler():
         print("Shutting down")
-
     ```
     </CodeGroup>
 
@@ -48,14 +43,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      @app.get("/")
-      async def h(request):
-          return "Hello, world"
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       from robyn import Request
 
       @app.get("/")
@@ -87,19 +75,7 @@ export const description =
 
     <CodeGroup title="Request" tag="POST" label="/http_requests">
 
-    ```python {{ title: 'untyped' }}
-    @app.before_request("/")
-    async def hello_before_request(request: Request):
-        request.headers["before"] = "sync_before_request"
-        return request
-
-    @app.after_request("/")
-    def hello_after_request(response: Response):
-        response.headers.set("after", "sync_after_request")
-        return response
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     from robyn import Request, Response
 
     @app.before_request("/")

--- a/docs_src/src/pages/documentation/zh/api_reference/multiprocess_execution.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/multiprocess_execution.mdx
@@ -21,33 +21,7 @@ Robyn 向他保证，确实支持在多进程环境中共享变量。换句话�
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-        import threading
-        import time
-        from multiprocessing import Value
-
-        from robyn import Robyn, Request
-
-        app = Robyn(__file__)
-
-        count = Value("i", 0)
-
-        def counter():
-            while True:
-                count.value += 1
-                time.sleep(0.2)
-                print(count.value, "added 1")
-
-        @app.get("/")
-        def index(request):
-            return f"{count.value}"
-
-        threading.Thread(target=counter, daemon=True).start()
-
-        app.start()
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
         import threading
         import time
         from multiprocessing import Value

--- a/docs_src/src/pages/documentation/zh/api_reference/openapi.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/openapi.mdx
@@ -28,62 +28,7 @@ python app.py --disable-openapi
 
 <CodeGroup title="Basic App">
 
-```python {{ title: 'untyped' }}
-from robyn import Robyn
-from robyn.robyn import QueryParams
-
-app = Robyn(
-    file_object=__file__,
-    openapi=OpenAPI(
-        info=OpenAPIInfo(
-            title="Sample App",
-            description="This is a sample server application.",
-            termsOfService="https://example.com/terms/",
-            version="1.0.0",
-            contact=Contact(
-                name="API Support",
-                url="https://www.example.com/support",
-                email="support@example.com",
-            ),
-            license=License(
-                name="BSD2.0",
-                url="https://opensource.org/license/bsd-2-clause",
-            ),
-            externalDocs=ExternalDocumentation(description="Find more info here", url="https://example.com/"),
-            components=Components(),
-        ),
-    ),
-)
-
-
-@app.get("/")
-async def welcome():
-    """欢迎"""
-    return "hi"
-
-
-class GetRequestParams(QueryParams):
-    appointment_id: str
-    year: int
-
-
-@app.get("/api/v1/name", openapi_name="Name Route", openapi_tags=["Name"])
-async def get(r, query_params: GetRequestParams):
-    """根据 ID 获取名称"""
-    return r.query_params
-
-
-@app.delete("/users/:name", openapi_tags=["Name"])
-async def delete(r):
-    """根据名称删除用户"""
-    return r.path_params
-
-
-if __name__ == "__main__":
-    app.start()
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.robyn import QueryParams
 
 from robyn import Robyn, Request
@@ -145,40 +90,7 @@ if __name__ == "__main__":
 
 <CodeGroup title="Subrouters">
 
-```python {{ title: 'untyped' }}
-from robyn import SubRouter
-from robyn.robyn import QueryParams
-
-subrouter = SubRouter(__name__, prefix="/sub")
-
-
-@subrouter.get("/")
-async def subrouter_welcome():
-    """welcome subrouter"""
-    return "hiiiiii subrouter"
-
-
-class SubRouterGetRequestParams(QueryParams):
-    _id: int
-    value: str
-
-
-@subrouter.get("/name")
-async def subrouter_get(r, query_params: SubRouterGetRequestParams):
-    """Get Name by ID"""
-    return r.query_params
-
-
-@subrouter.delete("/:name")
-async def subrouter_delete(r):
-    """Delete Name by ID"""
-    return r.path_params
-
-
-app.include_router(subrouter)
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.robyn import QueryParams
 
 from robyn import Request, SubRouter
@@ -220,38 +132,7 @@ We support all the params mentioned in the latest OpenAPI specifications (https:
 
 <CodeGroup title="Request & Response Body">
 
-```python {{ title: 'untyped' }}
-from robyn.types import JSONResponse, Body
-
-class Initial(Body):
-    is_present: bool
-    letter: Optional[str]
-
-
-class FullName(Body):
-    first: str
-    second: str
-    initial: Initial
-
-
-class CreateItemBody(Body):
-    name: FullName
-    description: str
-    price: float
-    tax: float
-
-
-class CreateResponse(JSONResponse):
-    success: bool
-    items_changed: int
-
-
-@app.post("/")
-def create_item(request: Request, body: CreateItemBody) -> CreateResponse:
-    return CreateResponse(success=True, items_changed=2)
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.types import JSONResponse, Body
 
 class Initial(Body):

--- a/docs_src/src/pages/documentation/zh/api_reference/redirection.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/redirection.mdx
@@ -8,7 +8,7 @@
   <Col sticky>
     <CodeGroup title="Request">
 
-      ```python {{title: 'untyped'}}
+      ```python
       from robyn import Robyn, Response
       app = Robyn(__file__)
 

--- a/docs_src/src/pages/documentation/zh/api_reference/request_object.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/request_object.mdx
@@ -42,24 +42,7 @@ identity (Optional[Identity])：客户端的身份
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    @dataclass
-    class Request:
-      """
-      query_params: QueryParams
-      headers: Headers
-      path_params: dict[str, str]
-      body: Union[str, bytes]
-      method: str
-      url: Url
-      form_data: dict[str, str]
-      files: dict[str, bytes]
-      ip_addr: Optional[str]
-      identity: Optional[Identity]
-      """
-    ```
-
-    ```python {{ title: 'typed' }}
+    ```python
     @dataclass
     class Request:
       """

--- a/docs_src/src/pages/documentation/zh/api_reference/scaling.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/scaling.mdx
@@ -8,11 +8,7 @@
   <Col sticky>
     <CodeGroup title="Request">
 
-      ```python {{ title: 'untyped' }}
-      python3 app.py --workers=N --process=M
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       python3 app.py --workers=N --process=M
       ```
     </CodeGroup>

--- a/docs_src/src/pages/documentation/zh/api_reference/templating.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/templating.mdx
@@ -13,22 +13,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{title: 'untyped'}}
-    from robyn.templating import JinjaTemplate
-
-    current_file_path = pathlib.Path(__file__).parent.resolve()
-    JINJA_TEMPLATE = JinjaTemplate(os.path.join(current_file_path, "templates"))
-
-    @app.get("/template_render")
-    def template_render():
-        context = {"framework": "Robyn", "templating_engine": "Jinja2"}
-
-        template = JINJA_TEMPLATE.render_template(template_name="test.html", **context)
-        return template
-
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn.templating import JinjaTemplate
 
     current_file_path = pathlib.Path(__file__).parent.resolve()
@@ -82,11 +67,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      from robyn.templating import TemplateInterface
-      ```
-
-      ```python {{ title: 'typed' }}
+      ```python
       from robyn.templating import TemplateInterface
       ```
     </CodeGroup>
@@ -101,20 +82,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      class JinjaTemplate(TemplateInterface):
-        def __init__(self, directory, encoding="utf-8", followlinks=False):
-            self.env = Environment(
-                loader=FileSystemLoader(
-                    searchpath=directory, encoding=encoding, followlinks=followlinks
-                )
-            )
-
-        def render_template(self, template_name, **kwargs):
-            return self.env.get_template(template_name).render(**kwargs)
-      ```
-
-      ```python {{ title: 'typed' }}
+      ```python
       class JinjaTemplate(TemplateInterface):
         def __init__(self, directory, encoding="utf-8", followlinks=False):
             self.env = Environment(

--- a/docs_src/src/pages/documentation/zh/api_reference/using_rust_directly.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/using_rust_directly.mdx
@@ -10,11 +10,7 @@
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    python -m robyn --create-rust-file hello_world
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     python -m robyn --create-rust-file hello_world
     ```
 
@@ -88,13 +84,7 @@
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      from hello_world import square
-
-      print(square(5))
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       from hello_world import square
 
       print(square(5))
@@ -108,11 +98,7 @@
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      python -m robyn --compile-rust-path "." --dev
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       python -m robyn --compile-rust-path "." --dev
       ```
     </CodeGroup>

--- a/docs_src/src/pages/documentation/zh/api_reference/views.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/views.mdx
@@ -16,18 +16,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    def sample_view():
-      def get():
-          return "Hello, world!"
-
-      def post(request):
-          body = request.body
-          return Response({"status_code": 200, "description": body, "headers": {}})
-
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
       from robyn import Request
 
       def sample_view():
@@ -54,18 +43,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      @app.view("/sync/view/decorator")
-      def sync_decorator_view():
-       def get():
-           return "Hello, world!"
-
-       def post(request):
-           body = request.body
-           return body
-
-      ```
-      ```python {{ title: 'typed' }}
+      ```python
       from robyn import Request
 
       @app.view("/sync/view/decorator")
@@ -90,15 +68,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-        from .views import sample_view
-
-        ...
-        ...
-
-        app.add_view("/", sample_view)
-      ```
-      ```python {{ title: 'typed' }}
+      ```python
         from .views import sample_view
 
         ...
@@ -129,28 +99,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      from robyn import Robyn, SubRouter
-
-      app = Robyn(__file__)
-
-      sub_router = SubRouter("/sub_router")
-
-      @sub_router.get("/hello")
-      def hello():
-          return "Hello, world"
-
-      web_socket = SubRouter("/web_socket")
-
-      @web_socket.message()
-      async def hello():
-          return "Hello, world"
-
-      app.include_router(sub_router)
-      ```
-
-
-      ```python {{ title: 'typed' }}
+      ```python
       from robyn import Robyn, SubRouter
 
       app = Robyn(__file__)

--- a/docs_src/src/pages/documentation/zh/api_reference/websockets.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/websockets.mdx
@@ -15,28 +15,7 @@ export const description =
 
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-    ```python {{ title: 'untyped' }}
-    from robyn import Robyn, jsonify, WebSocket
-
-    app = Robyn(__file__)
-    websocket = WebSocket(app, "/web_socket")
-
-    @websocket.on("message")
-    def connect():
-        return "Hello world, from ws"
-
-    @websocket.on("close")
-    def close():
-        return "Goodbye world, from ws"
-
-    @websocket.on("connect")
-    def message():
-        return "Connected to ws"
-
-
-    ```
-
-    ```python {{title: 'typed'}}
+    ```python
     from robyn import Robyn, jsonify, WebSocket
 
     app = Robyn(__file__)
@@ -76,31 +55,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="可选返回值" tag="WebSocket" label="/web_socket">
 
-      ```python {{ title: 'untyped' }}
-      from robyn import Robyn, WebSocket
-
-      app = Robyn(__file__)
-      websocket = WebSocket(app, "/web_socket")
-
-      @websocket.on("connect")
-      async def connect():
-          # 无需返回 - 仅记录连接
-          print("客户端已连接")
-
-      @websocket.on("message")
-      def message(ws, msg):
-          # 处理消息但不响应
-          process_analytics(msg)
-          # 无需返回语句
-
-      @websocket.on("close")
-      async def close():
-          # 显式返回 None - 不发送消息
-          cleanup_resources()
-          return None
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       from robyn import Robyn, WebSocket, WebSocketConnector
 
       app = Robyn(__file__)
@@ -135,17 +90,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            ws.sync_send_to(websocket_id, "This is a message to self")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
@@ -168,17 +113,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        async def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            await ws.async_send_to(websocket_id, "This is a message to self")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         async def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
@@ -200,17 +135,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            ws.sync_broadcast("This is a message to self")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
@@ -231,17 +156,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        async def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            await ws.async_broadcast("This is a message to self")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         async def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
@@ -262,18 +177,7 @@ export const description =
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world?name=gordon&desg=commissioner">
 
-      ```python {{ title: 'untyped' }}
-
-        @websocket.on("message")
-        async def message(ws, msg, global_dependencies) -> str:
-            websocket_id = ws.id
-            if (ws.query_params.get("name") == "gordon" and ws.query_params.get("desg") == "commissioner"):
-              ws.sync_broadcast("Gordon authorized to login!")
-            return ""
-
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
 
         @websocket.on("message")
         async def message(ws: WebSocketConnector, msg: str, global_dependencies) -> str:
@@ -301,16 +205,7 @@ export const description =
   <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
-      ```python {{ title: 'untyped' }}
-      @websocket.on("message")
-      def message(ws, msg):
-          if msg == "disconnect":
-              ws.close()
-              return "Closing connection"
-          return "Message received"
-      ```
-
-      ```python {{title: 'typed'}}
+      ```python
       @websocket.on("message")
       def message(ws: WebSocketConnector, msg: str) -> str:
           if msg == "disconnect":

--- a/docs_src/src/pages/documentation/zh/example_app/openapi.mdx
+++ b/docs_src/src/pages/documentation/zh/example_app/openapi.mdx
@@ -28,62 +28,7 @@ python app.py --disable-openapi
 
 <CodeGroup title="基础应用">
 
-```python {{ title: 'untyped' }}
-from robyn import Robyn
-from robyn.robyn import QueryParams
-
-app = Robyn(
-    file_object=__file__,
-    openapi=OpenAPI(
-        info=OpenAPIInfo(
-            title="Sample App",
-            description="This is a sample server application.",
-            termsOfService="https://example.com/terms/",
-            version="1.0.0",
-            contact=Contact(
-                name="API Support",
-                url="https://www.example.com/support",
-                email="support@example.com",
-            ),
-            license=License(
-                name="BSD2.0",
-                url="https://opensource.org/license/bsd-2-clause",
-            ),
-            externalDocs=ExternalDocumentation(description="Find more info here", url="https://example.com/"),
-            components=Components(),
-        ),
-    ),
-)
-
-
-@app.get("/")
-async def welcome():
-    """欢迎"""
-    return "hi"
-
-
-class GetRequestParams(QueryParams):
-    appointment_id: str
-    year: int
-
-
-@app.get("/api/v1/name", openapi_name="Name Route", openapi_tags=["Name"])
-async def get(r, query_params: GetRequestParams):
-    """根据 ID 获取名称"""
-    return r.query_params
-
-
-@app.delete("/users/:name", openapi_tags=["Name"])
-async def delete(r):
-    """根据名称删除用户"""
-    return r.path_params
-
-
-if __name__ == "__main__":
-    app.start()
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.robyn import QueryParams
 
 from robyn import Robyn, Request
@@ -145,40 +90,7 @@ if __name__ == "__main__":
 
 <CodeGroup title="子路由">
 
-```python {{ title: 'untyped' }}
-from robyn import SubRouter
-from robyn.robyn import QueryParams
-
-subrouter = SubRouter(__name__, prefix="/sub")
-
-
-@subrouter.get("/")
-async def subrouter_welcome():
-    """欢迎来到子路由"""
-    return "hiiiiii subrouter"
-
-
-class SubRouterGetRequestParams(QueryParams):
-    _id: int
-    value: str
-
-
-@subrouter.get("/name")
-async def subrouter_get(r, query_params: SubRouterGetRequestParams):
-    """"根据 ID 获取名称""
-    return r.query_params
-
-
-@subrouter.delete("/:name")
-async def subrouter_delete(r):
-    """根据名称删除用户"""
-    return r.path_params
-
-
-app.include_router(subrouter)
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.robyn import QueryParams
 
 from robyn import Request, SubRouter
@@ -220,38 +132,7 @@ Robyn 支持最新的 OpenAPI 规范（[https://swagger.io/specification/](https
 
 <CodeGroup title="请求 & 响应体">
 
-```python {{ title: 'untyped' }}
-from robyn.types import JSONResponse, Body
-
-class Initial(Body):
-    is_present: bool
-    letter: Optional[str]
-
-
-class FullName(Body):
-    first: str
-    second: str
-    initial: Initial
-
-
-class CreateItemBody(Body):
-    name: FullName
-    description: str
-    price: float
-    tax: float
-
-
-class CreateResponse(JSONResponse):
-    success: bool
-    items_changed: int
-
-
-@app.post("/")
-def create_item(request: Request, body: CreateItemBody) -> CreateResponse:
-    return CreateResponse(success=True, items_changed=2)
-```
-
-```python {{ title: 'typed' }}
+```python
 from robyn.types import JSONResponse, Body
 
 class Initial(Body):


### PR DESCRIPTION
## Description

This PR fixes #1304 

## Summary

This PR removes the distinction between typed and untyped code

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified API reference examples across English and Chinese documentation by removing untyped code variants and consolidating to single typed code blocks.
  * Added comprehensive type annotations to function parameters and variables throughout all code examples.
  * Streamlined configuration examples for OpenAPI, WebSockets, dependency injection, and templating features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->