### PR TITLE
fix: improve OpenAPI schema generation for complex types

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -1232,6 +1232,11 @@ class FullName(Body):
     initial: Initial
 
 
+class TestTypedBody(Body):
+    items: List[str]
+    numbers: list[int]
+
+
 class CreateItemBody(Body):
     name: FullName
     description: str
@@ -1251,6 +1256,11 @@ class CreateItemQueryParamsParams(QueryParams):
 @app.post("/openapi_request_body")
 def create_item(request, body: CreateItemBody, query: CreateItemQueryParamsParams) -> CreateItemResponse:
     return CreateItemResponse(success=True, items_changed=2)
+
+
+@app.post("/sync/body/typed")
+def sync_body_typed(body: TestTypedBody):
+    return "OK"
 
 
 # ===== JsonBody Routes =====

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -7,7 +7,7 @@ from dataclasses import asdict, dataclass, field
 from importlib import resources
 from inspect import Signature
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, is_typeddict
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, Union, is_typeddict
 
 from robyn.pydantic_support import get_pydantic_openapi_schema, is_pydantic_model
 from robyn.responses import html
@@ -425,13 +425,22 @@ class OpenAPI:
 
         # Check if it's a generic type (like List[Object])
         if hasattr(param_type, "__origin__"):
-            if param_type.__origin__ is list or param_type.__origin__ is List:
+            origin = getattr(param_type, "__origin__", None)
+            args = getattr(param_type, "__args__", ())
+
+            if origin is list or (hasattr(typing, "List") and origin is list):
                 properties["type"] = "array"
-                # Handle the element type in the list
-                if hasattr(param_type, "__args__") and param_type.__args__:
-                    item_type = param_type.__args__[0]
+                if args:
+                    item_type = args[0]
                     properties["items"] = self.get_schema_object(f"{parameter}_item", item_type)
                 return properties
+
+            # Handle Optional/Union types
+            if origin is Union:
+                non_none_args = [a for a in args if a is not type(None)]
+                if len(non_none_args) == 1 and type(None) in args:
+                    properties["anyOf"] = [self.get_schema_object(parameter, non_none_args[0]), {"type": "null"}]
+                    return properties
 
         # check for Pydantic models
         if is_pydantic_model(param_type):
@@ -440,21 +449,22 @@ class OpenAPI:
                 self._merge_component_schemas(component_schemas)
             return schema
 
-        # check for Optional type
-        if param_type.__module__ == "typing":
-            properties["anyOf"] = [{"type": self.get_openapi_type(param_type.__args__[0])}, {"type": "null"}]
-            return properties
         # check for custom classes and TypedDicts
-        elif inspect.isclass(param_type):
+        if inspect.isclass(param_type):
             properties["type"] = "object"
-
             properties["properties"] = {}
+            if hasattr(param_type, "__annotations__"):
+                for e in param_type.__annotations__:
+                    properties["properties"][e] = self.get_schema_object(e, param_type.__annotations__[e])
+            return properties
 
-            for e in param_type.__annotations__:
-                properties["properties"][e] = self.get_schema_object(e, param_type.__annotations__[e])
+        # check for Optional type (legacy path)
+        if hasattr(param_type, "__module__") and param_type.__module__ == "typing":
+            if hasattr(param_type, "__args__"):
+                properties["anyOf"] = [{"type": self.get_openapi_type(param_type.__args__[0])}, {"type": "null"}]
+                return properties
 
         properties["type"] = "object"
-
         return properties
 
     def override_openapi(self, openapi_json_spec_path: Path):

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -439,7 +439,18 @@ class OpenAPI:
             if origin is Union:
                 non_none_args = [a for a in args if a is not type(None)]
                 if len(non_none_args) == 1 and type(None) in args:
-                    properties["anyOf"] = [self.get_schema_object(parameter, non_none_args[0]), {"type": "null"}]
+                    inner = non_none_args[0]
+                    # For primitive types, emit the minimal legacy form
+                    # `{"type": "<openapi>"}` — otherwise callers that assert
+                    # equality on the branch dict (e.g. existing integration
+                    # tests) break because `get_schema_object` would inject a
+                    # `title` key via the recursive call. For complex inner
+                    # types we still recurse so class fields are captured.
+                    if inner in type_mapping:
+                        inner_schema: dict = {"type": type_mapping[inner]}
+                    else:
+                        inner_schema = self.get_schema_object(parameter, inner)
+                    properties["anyOf"] = [inner_schema, {"type": "null"}]
                     return properties
 
         # check for Pydantic models

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import logging
 import re
+import types
 import typing
 from dataclasses import asdict, dataclass, field
 from importlib import resources
@@ -423,44 +424,39 @@ class OpenAPI:
                 properties["type"] = type_mapping[type_name]
                 return properties
 
-        # Check if it's a generic type (like List[Object])
-        if hasattr(param_type, "__origin__"):
-            origin = getattr(param_type, "__origin__", None)
-            args = getattr(param_type, "__args__", ())
+        origin = typing.get_origin(param_type)
+        args = typing.get_args(param_type)
 
-            if origin is list or (hasattr(typing, "List") and origin is list):
-                properties["type"] = "array"
-                if args:
-                    item_type = args[0]
-                    properties["items"] = self.get_schema_object(f"{parameter}_item", item_type)
-                return properties
+        if origin is list:
+            properties["type"] = "array"
+            if args:
+                item_type = args[0]
+                properties["items"] = self.get_schema_object(f"{parameter}_item", item_type)
+            return properties
 
-            # Handle Optional/Union types
-            if origin is Union:
-                non_none_args = [a for a in args if a is not type(None)]
-                if len(non_none_args) == 1 and type(None) in args:
-                    inner = non_none_args[0]
-                    # For primitive types, emit the minimal legacy form
-                    # `{"type": "<openapi>"}` — otherwise callers that assert
-                    # equality on the branch dict (e.g. existing integration
-                    # tests) break because `get_schema_object` would inject a
-                    # `title` key via the recursive call. For complex inner
-                    # types we still recurse so class fields are captured.
-                    if inner in type_mapping:
-                        inner_schema: dict = {"type": type_mapping[inner]}
-                    else:
-                        inner_schema = self.get_schema_object(parameter, inner)
-                    properties["anyOf"] = [inner_schema, {"type": "null"}]
-                    return properties
+        is_union = origin is Union or isinstance(param_type, types.UnionType)
+        if is_union and args:
+            non_none_args = [a for a in args if a is not type(None)]
+            nullable = type(None) in args
 
-        # check for Pydantic models
+            any_of = []
+            for arg in non_none_args:
+                if arg in type_mapping:
+                    any_of.append({"type": type_mapping[arg]})
+                else:
+                    any_of.append(self.get_schema_object(parameter, arg))
+            if nullable:
+                any_of.append({"type": "null"})
+
+            properties["anyOf"] = any_of
+            return properties
+
         if is_pydantic_model(param_type):
             schema, component_schemas = get_pydantic_openapi_schema(param_type)
             if component_schemas:
                 self._merge_component_schemas(component_schemas)
             return schema
 
-        # check for custom classes and TypedDicts
         if inspect.isclass(param_type):
             properties["type"] = "object"
             properties["properties"] = {}
@@ -468,12 +464,6 @@ class OpenAPI:
                 for e in param_type.__annotations__:
                     properties["properties"][e] = self.get_schema_object(e, param_type.__annotations__[e])
             return properties
-
-        # check for Optional type (legacy path)
-        if hasattr(param_type, "__module__") and param_type.__module__ == "typing":
-            if hasattr(param_type, "__args__"):
-                properties["anyOf"] = [{"type": self.get_openapi_type(param_type.__args__[0])}, {"type": "null"}]
-                return properties
 
         properties["type"] = "object"
         return properties

--- a/unit_tests/test_openapi_schema.py
+++ b/unit_tests/test_openapi_schema.py
@@ -1,0 +1,36 @@
+import typing
+
+from robyn.openapi import OpenAPI
+
+
+def test_schema_basic_types():
+    api = OpenAPI()
+    assert api.get_schema_object("test", int)["type"] == "integer"
+    assert api.get_schema_object("test", str)["type"] == "string"
+    assert api.get_schema_object("test", bool)["type"] == "boolean"
+    assert api.get_schema_object("test", float)["type"] == "number"
+
+
+def test_schema_list_type():
+    api = OpenAPI()
+    schema = api.get_schema_object("test", typing.List[str])
+    assert schema["type"] == "array"
+    assert "items" in schema
+
+
+def test_schema_optional_type():
+    api = OpenAPI()
+    schema = api.get_schema_object("test", typing.Optional[str])
+    assert "anyOf" in schema
+
+
+def test_schema_custom_class():
+    class MyModel:
+        name: str
+        age: int
+
+    api = OpenAPI()
+    schema = api.get_schema_object("test", MyModel)
+    assert schema["type"] == "object"
+    assert "name" in schema["properties"]
+    assert "age" in schema["properties"]

--- a/unit_tests/test_openapi_schema.py
+++ b/unit_tests/test_openapi_schema.py
@@ -5,23 +5,106 @@ from robyn.openapi import OpenAPI
 
 def test_schema_basic_types():
     api = OpenAPI()
-    assert api.get_schema_object("test", int)["type"] == "integer"
-    assert api.get_schema_object("test", str)["type"] == "string"
-    assert api.get_schema_object("test", bool)["type"] == "boolean"
-    assert api.get_schema_object("test", float)["type"] == "number"
+    assert api.get_schema_object("test", int) == {"title": "Test", "type": "integer"}
+    assert api.get_schema_object("test", str) == {"title": "Test", "type": "string"}
+    assert api.get_schema_object("test", bool) == {"title": "Test", "type": "boolean"}
+    assert api.get_schema_object("test", float) == {"title": "Test", "type": "number"}
+    assert api.get_schema_object("test", dict) == {"title": "Test", "type": "object"}
+    assert api.get_schema_object("test", list) == {"title": "Test", "type": "array"}
 
 
-def test_schema_list_type():
+def test_schema_typing_list():
     api = OpenAPI()
     schema = api.get_schema_object("test", typing.List[str])
     assert schema["type"] == "array"
-    assert "items" in schema
+    assert schema["items"] == {"title": "Test_item", "type": "string"}
 
 
-def test_schema_optional_type():
+def test_schema_builtin_generic_list():
+    api = OpenAPI()
+    schema = api.get_schema_object("test", list[int])
+    assert schema["type"] == "array"
+    assert schema["items"] == {"title": "Test_item", "type": "integer"}
+
+
+def test_schema_list_of_custom_class():
+    class Item:
+        name: str
+        count: int
+
+    api = OpenAPI()
+    schema = api.get_schema_object("test", typing.List[Item])
+    assert schema["type"] == "array"
+    assert schema["items"]["type"] == "object"
+    assert "name" in schema["items"]["properties"]
+    assert "count" in schema["items"]["properties"]
+
+
+def test_schema_optional_primitive():
     api = OpenAPI()
     schema = api.get_schema_object("test", typing.Optional[str])
     assert "anyOf" in schema
+    assert {"type": "string"} in schema["anyOf"]
+    assert {"type": "null"} in schema["anyOf"]
+
+
+def test_schema_optional_custom_class():
+    class Widget:
+        label: str
+
+    api = OpenAPI()
+    schema = api.get_schema_object("test", typing.Optional[Widget])
+    assert "anyOf" in schema
+    assert {"type": "null"} in schema["anyOf"]
+    non_null = [s for s in schema["anyOf"] if s != {"type": "null"}]
+    assert len(non_null) == 1
+    assert non_null[0]["type"] == "object"
+    assert "label" in non_null[0]["properties"]
+
+
+def test_schema_union_multiple_primitives():
+    api = OpenAPI()
+    schema = api.get_schema_object("test", typing.Union[str, int])
+    assert "anyOf" in schema
+    assert {"type": "string"} in schema["anyOf"]
+    assert {"type": "integer"} in schema["anyOf"]
+    assert {"type": "null"} not in schema["anyOf"]
+
+
+def test_schema_union_nullable_multiple():
+    api = OpenAPI()
+    schema = api.get_schema_object("test", typing.Union[str, int, None])
+    assert "anyOf" in schema
+    assert {"type": "string"} in schema["anyOf"]
+    assert {"type": "integer"} in schema["anyOf"]
+    assert {"type": "null"} in schema["anyOf"]
+
+
+def test_schema_pep604_union():
+    api = OpenAPI()
+    schema = api.get_schema_object("test", str | int)
+    assert "anyOf" in schema
+    assert {"type": "string"} in schema["anyOf"]
+    assert {"type": "integer"} in schema["anyOf"]
+
+
+def test_schema_pep604_optional():
+    api = OpenAPI()
+    schema = api.get_schema_object("test", str | None)
+    assert "anyOf" in schema
+    assert {"type": "string"} in schema["anyOf"]
+    assert {"type": "null"} in schema["anyOf"]
+
+
+def test_schema_nested_optional_list():
+    api = OpenAPI()
+    schema = api.get_schema_object("test", typing.Optional[typing.List[str]])
+    assert "anyOf" in schema
+    assert {"type": "null"} in schema["anyOf"]
+    non_null = [s for s in schema["anyOf"] if s != {"type": "null"}]
+    assert len(non_null) == 1
+    assert non_null[0]["type"] == "array"
+    assert non_null[0]["items"]["type"] == "string"
 
 
 def test_schema_custom_class():
@@ -34,3 +117,5 @@ def test_schema_custom_class():
     assert schema["type"] == "object"
     assert "name" in schema["properties"]
     assert "age" in schema["properties"]
+    assert schema["properties"]["name"]["type"] == "string"
+    assert schema["properties"]["age"]["type"] == "integer"


### PR DESCRIPTION
## Summary
- Fixes OpenAPI schema generation for `Optional`, `List`, `Union`, and custom class types that previously caused `AttributeError` when `param_type` lacked a `__module__` attribute
- Uses `typing.get_origin()` / `typing.get_args()` and `hasattr` guards for reliable type introspection instead of directly accessing `__module__`
- Adds integration test route with typed `Body` containing `List[str]` and `list[int]` fields, plus unit tests covering basic types, list types, optional types, and custom classes

Supersedes #1054

## Test plan
- [ ] Unit tests in `unit_tests/test_openapi_schema.py` pass (basic types, List, Optional, custom class)
- [ ] Integration test route `/sync/body/typed` registers correctly with OpenAPI spec
- [ ] Existing OpenAPI tests continue to pass
- [ ] Manual verification: `Optional[str]`, `List[SomeClass]`, and plain custom classes produce correct schema output

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new synchronous POST endpoint to accept typed request bodies and return confirmation.

* **Improvements**
  * Improved OpenAPI generation for generics, unions/optional types, and class-based request body schemas — resulting in more accurate API docs.

* **Tests**
  * Added unit tests covering schema generation for primitives, collections, optionals/unions, and custom classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->