### PR TITLE
feat: add Depends() callable dependency injection

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -23,6 +23,7 @@ from robyn.reloader import compile_rust_files
 from robyn.responses import SSEMessage, SSEResponse, StreamingResponse, html, serve_file, serve_html
 from robyn.robyn import FunctionInfo, Headers, HttpMethod, Request, Response, WebSocketConnector, get_version
 from robyn.router import MiddlewareRouter, MiddlewareType, Router, WebSocketRouter
+from robyn.depends import Depends
 from robyn.types import Directory, JsonBody
 from robyn.ws import WebSocketAdapter, WebSocketDisconnect, create_websocket_decorator
 
@@ -811,4 +812,5 @@ __all__ = [
     "WebSocketDisconnect",
     "JsonBody",
     "MCPApp",
+    "Depends",
 ]

--- a/robyn/depends.py
+++ b/robyn/depends.py
@@ -31,7 +31,10 @@ class Depends:
         self.use_cache = use_cache
 
     def __repr__(self) -> str:
-        return f"Depends({self.dependency.__name__})"
+        name = getattr(self.dependency, "__name__", None) or getattr(
+            self.dependency, "__qualname__", repr(self.dependency)
+        )
+        return f"Depends({name})"
 
 
 def _detect_depends_params(handler_params: dict) -> Dict[str, "Depends"]:
@@ -89,8 +92,12 @@ async def resolve_dependencies(depends_params: Dict[str, Depends], request) -> t
     cache: dict = {}
     resolved = {}
 
-    for param_name, dep in depends_params.items():
-        resolved[param_name] = await _resolve_dependency(dep, request, cache)
+    try:
+        for param_name, dep in depends_params.items():
+            resolved[param_name] = await _resolve_dependency(dep, request, cache)
+    except Exception:
+        await cleanup_dependencies(cache)
+        raise
 
     return resolved, cache
 

--- a/robyn/depends.py
+++ b/robyn/depends.py
@@ -31,9 +31,7 @@ class Depends:
         self.use_cache = use_cache
 
     def __repr__(self) -> str:
-        name = getattr(self.dependency, "__name__", None) or getattr(
-            self.dependency, "__qualname__", repr(self.dependency)
-        )
+        name = getattr(self.dependency, "__name__", None) or getattr(self.dependency, "__qualname__", repr(self.dependency))
         return f"Depends({name})"
 
 

--- a/robyn/depends.py
+++ b/robyn/depends.py
@@ -1,0 +1,116 @@
+import asyncio
+import inspect
+import logging
+from typing import Any, Callable, Dict
+
+_logger = logging.getLogger(__name__)
+
+
+class Depends:
+    """Mark a handler parameter as a dependency to be resolved at request time.
+
+    Usage::
+
+        async def get_db():
+            db = create_connection()
+            try:
+                yield db
+            finally:
+                db.close()
+
+        def get_current_user(request: Request):
+            token = request.headers.get("Authorization")
+            return verify_token(token)
+
+        @app.get("/items")
+        async def list_items(db=Depends(get_db), user=Depends(get_current_user)):
+            return db.query("SELECT * FROM items WHERE user_id = ?", user.id)
+    """
+
+    def __init__(self, dependency: Callable, *, use_cache: bool = True) -> None:
+        self.dependency = dependency
+        self.use_cache = use_cache
+
+    def __repr__(self) -> str:
+        return f"Depends({self.dependency.__name__})"
+
+
+def _detect_depends_params(handler_params: dict) -> Dict[str, "Depends"]:
+    """Find parameters with Depends() as their default value."""
+    depends_params = {}
+    for name, param in handler_params.items():
+        if isinstance(param.default, Depends):
+            depends_params[name] = param.default
+    return depends_params
+
+
+async def _resolve_dependency(dep: Depends, request, cache: dict) -> Any:
+    """Resolve a single dependency, handling both sync and async callables,
+    and generator-based dependencies (for cleanup support)."""
+    dep_id = id(dep.dependency)
+
+    if dep.use_cache and dep_id in cache:
+        return cache[dep_id]
+
+    func = dep.dependency
+    sig = inspect.signature(func)
+    kwargs = {}
+
+    for param_name, param in sig.parameters.items():
+        if param_name in ("request", "req", "r"):
+            kwargs[param_name] = request
+        elif isinstance(param.default, Depends):
+            kwargs[param_name] = await _resolve_dependency(param.default, request, cache)
+
+    if inspect.isasyncgenfunction(func):
+        gen = func(**kwargs)
+        value = await gen.__anext__()
+        cache[f"__cleanup_{dep_id}"] = gen
+    elif inspect.isgeneratorfunction(func):
+        gen = func(**kwargs)
+        value = next(gen)
+        cache[f"__cleanup_{dep_id}"] = gen
+    elif inspect.iscoroutinefunction(func):
+        value = await func(**kwargs)
+    else:
+        value = func(**kwargs)
+
+    if dep.use_cache:
+        cache[dep_id] = value
+
+    return value
+
+
+async def resolve_dependencies(depends_params: Dict[str, Depends], request) -> tuple:
+    """Resolve all dependencies for a handler.
+
+    Returns:
+        (resolved_kwargs, cache) - the resolved values and the cache (for cleanup)
+    """
+    cache: dict = {}
+    resolved = {}
+
+    for param_name, dep in depends_params.items():
+        resolved[param_name] = await _resolve_dependency(dep, request, cache)
+
+    return resolved, cache
+
+
+async def cleanup_dependencies(cache: dict) -> None:
+    """Clean up generator-based dependencies."""
+    for key, value in list(cache.items()):
+        if not str(key).startswith("__cleanup_"):
+            continue
+        try:
+            if inspect.isasyncgen(value):
+                try:
+                    await value.__anext__()
+                except StopAsyncIteration:
+                    pass
+            elif inspect.isgenerator(value):
+                try:
+                    next(value)
+                except StopIteration:
+                    pass
+        except Exception:
+            _logger.exception("Error during dependency cleanup for %s", key)

--- a/robyn/depends.py
+++ b/robyn/depends.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 import logging
 from typing import Any, Callable, Dict

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -8,7 +8,7 @@ from typing import Callable, Dict, List, NamedTuple, Optional, Union, is_typeddi
 
 from robyn import status_codes
 from robyn._param_utils import QueryParamValidationError, parse_route_param_names, resolve_individual_params
-from robyn.depends import Depends, _detect_depends_params, cleanup_dependencies, resolve_dependencies
+from robyn.depends import _detect_depends_params, cleanup_dependencies, resolve_dependencies
 from robyn.authentication import AuthenticationHandler, AuthenticationNotConfiguredError
 from robyn.dependency_injection import DependencyMap
 from robyn.jsonify import jsonify

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import logging
 from abc import ABC, abstractmethod
@@ -7,6 +8,7 @@ from typing import Callable, Dict, List, NamedTuple, Optional, Union, is_typeddi
 
 from robyn import status_codes
 from robyn._param_utils import QueryParamValidationError, parse_route_param_names, resolve_individual_params
+from robyn.depends import Depends, _detect_depends_params, cleanup_dependencies, resolve_dependencies
 from robyn.authentication import AuthenticationHandler, AuthenticationNotConfiguredError
 from robyn.dependency_injection import DependencyMap
 from robyn.jsonify import jsonify
@@ -158,6 +160,9 @@ class Router(BaseRouter):
         pydantic_params = detect_pydantic_params(handler_params)
         check_pydantic_installed_for_handler(handler, pydantic_params)
 
+        # Detect Depends() params once at registration (zero cost if not used)
+        depends_params = _detect_depends_params(handler_params)
+
         if pydantic_params and route_type in (HttpMethod.GET, HttpMethod.HEAD):
             _logger.warning(
                 "Handler '%s' on %s '%s' uses Pydantic body parameter(s) %s, but %s requests typically do not carry a request body",
@@ -259,6 +264,7 @@ class Router(BaseRouter):
 
             # Phase 3: Individual path/query param resolution
             unresolved_names = set(handler_params) - set(filtered_params)
+            unresolved_names -= set(depends_params.keys())
             if unresolved_names:
                 unresolved = {name: handler_params[name] for name in unresolved_names}
                 individual_params = resolve_individual_params(
@@ -273,7 +279,12 @@ class Router(BaseRouter):
 
         @wraps(handler)
         async def async_inner_handler(*args, **kwargs):
+            dep_cache = None
             try:
+                if depends_params:
+                    request = next(filter(lambda it: isinstance(it, Request), args), None)
+                    dep_kwargs, dep_cache = await resolve_dependencies(depends_params, request)
+                    kwargs.update(dep_kwargs)
                 response = self._format_response(
                     await wrapped_handler(*args, **kwargs),
                 )
@@ -295,11 +306,23 @@ class Router(BaseRouter):
                 response = self._format_response(
                     exception_handler(err),
                 )
+            finally:
+                if dep_cache is not None:
+                    await cleanup_dependencies(dep_cache)
             return response
 
         @wraps(handler)
         def inner_handler(*args, **kwargs):
+            dep_cache = None
             try:
+                if depends_params:
+                    request = next(filter(lambda it: isinstance(it, Request), args), None)
+                    loop = asyncio.new_event_loop()
+                    try:
+                        dep_kwargs, dep_cache = loop.run_until_complete(resolve_dependencies(depends_params, request))
+                    finally:
+                        loop.close()
+                    kwargs.update(dep_kwargs)
                 response = self._format_response(
                     wrapped_handler(*args, **kwargs),
                 )
@@ -321,6 +344,13 @@ class Router(BaseRouter):
                 response = self._format_response(
                     exception_handler(err),
                 )
+            finally:
+                if dep_cache is not None:
+                    loop = asyncio.new_event_loop()
+                    try:
+                        loop.run_until_complete(cleanup_dependencies(dep_cache))
+                    finally:
+                        loop.close()
             return response
 
         params = dict(handler_params)

--- a/unit_tests/test_depends.py
+++ b/unit_tests/test_depends.py
@@ -1,0 +1,130 @@
+import asyncio
+import inspect
+
+from robyn.depends import Depends, _detect_depends_params, cleanup_dependencies, resolve_dependencies
+
+
+def test_depends_repr():
+    def my_dep():
+        return 42
+
+    d = Depends(my_dep)
+    assert "my_dep" in repr(d)
+
+
+def test_detect_depends_params():
+    def get_db():
+        return "db"
+
+    def handler(request, db=Depends(get_db)):
+        pass
+
+    params = dict(inspect.signature(handler).parameters)
+    detected = _detect_depends_params(params)
+    assert "db" in detected
+    assert detected["db"].dependency is get_db
+    assert "request" not in detected
+
+
+def test_resolve_simple_dependency():
+    def get_value():
+        return 42
+
+    depends_params = {"value": Depends(get_value)}
+
+    loop = asyncio.new_event_loop()
+    resolved, cache = loop.run_until_complete(resolve_dependencies(depends_params, None))
+    loop.close()
+
+    assert resolved["value"] == 42
+
+
+def test_resolve_generator_dependency():
+    cleanup_called = False
+
+    def get_resource():
+        nonlocal cleanup_called
+        yield "resource"
+        cleanup_called = True
+
+    depends_params = {"res": Depends(get_resource)}
+
+    loop = asyncio.new_event_loop()
+    resolved, cache = loop.run_until_complete(resolve_dependencies(depends_params, None))
+    assert resolved["res"] == "resource"
+    assert not cleanup_called
+
+    loop.run_until_complete(cleanup_dependencies(cache))
+    loop.close()
+    assert cleanup_called
+
+
+def test_resolve_async_dependency():
+    async def get_async_value():
+        return "async_result"
+
+    depends_params = {"val": Depends(get_async_value)}
+
+    loop = asyncio.new_event_loop()
+    resolved, cache = loop.run_until_complete(resolve_dependencies(depends_params, None))
+    loop.close()
+
+    assert resolved["val"] == "async_result"
+
+
+def test_sub_dependencies():
+    def dep_a():
+        return "a"
+
+    def dep_b(a=Depends(dep_a)):
+        return f"b({a})"
+
+    depends_params = {"result": Depends(dep_b)}
+
+    loop = asyncio.new_event_loop()
+    resolved, cache = loop.run_until_complete(resolve_dependencies(depends_params, None))
+    loop.close()
+
+    assert resolved["result"] == "b(a)"
+
+
+def test_dependency_caching():
+    call_count = 0
+
+    def expensive():
+        nonlocal call_count
+        call_count += 1
+        return "value"
+
+    depends_params = {
+        "a": Depends(expensive),
+        "b": Depends(expensive),
+    }
+
+    loop = asyncio.new_event_loop()
+    resolved, cache = loop.run_until_complete(resolve_dependencies(depends_params, None))
+    loop.close()
+
+    assert resolved["a"] == "value"
+    assert resolved["b"] == "value"
+    assert call_count == 1
+
+
+def test_depends_no_cache():
+    call_count = 0
+
+    def counter():
+        nonlocal call_count
+        call_count += 1
+        return call_count
+
+    depends_params = {
+        "a": Depends(counter, use_cache=False),
+        "b": Depends(counter, use_cache=False),
+    }
+
+    loop = asyncio.new_event_loop()
+    resolved, cache = loop.run_until_complete(resolve_dependencies(depends_params, None))
+    loop.close()
+
+    assert call_count == 2


### PR DESCRIPTION
## Summary

- Adds a `Depends()` marker class for declarative dependency injection in route handlers, supporting sync/async callables, generator-based lifecycle management (yield for setup/teardown), sub-dependency resolution, and per-request caching.
- Integrates dependency resolution into `Router.add_route()` so that `Depends()` parameters are detected once at registration time and resolved transparently before handler invocation, with automatic cleanup of generator-based dependencies in a `finally` block.
- Exports `Depends` from the top-level `robyn` package and adds comprehensive unit tests covering repr, detection, simple/async/generator resolution, sub-dependencies, caching, and cache-bypass.

## Usage

```python
from robyn import Robyn, Depends

async def get_db():
    db = create_connection()
    try:
        yield db
    finally:
        db.close()

def get_current_user(request):
    token = request.headers.get("Authorization")
    return verify_token(token)

app = Robyn(__file__)

@app.get("/items")
async def list_items(db=Depends(get_db), user=Depends(get_current_user)):
    return db.query("SELECT * FROM items WHERE user_id = ?", user.id)
```

## Test plan

- [x] All 8 new unit tests pass (`test_depends_repr`, `test_detect_depends_params`, `test_resolve_simple_dependency`, `test_resolve_generator_dependency`, `test_resolve_async_dependency`, `test_sub_dependencies`, `test_dependency_caching`, `test_depends_no_cache`)
- [x] All 17 existing unit tests continue to pass (no regressions)
- [ ] Integration test with a live Robyn app using `Depends()` in route handlers


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependency injection for request handlers via a public Depends marker (now importable from the top-level package).
  * Support for sync, async, and generator-based dependencies with optional per-dependency caching.
  * Automatic cleanup/teardown for generator-based dependencies to ensure proper resource release.

* **Tests**
  * Added comprehensive tests covering resolution, nesting, caching, and cleanup behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->